### PR TITLE
feat: Discord Market Bot — Slash Commands + Rich Embeds (Issue #10)

### DIFF
--- a/discord-bot/.env.example
+++ b/discord-bot/.env.example
@@ -1,0 +1,6 @@
+# Discord Bot Configuration
+DISCORD_TOKEN=your_discord_bot_token_here
+DISCORD_CLIENT_ID=your_discord_application_id_here
+
+# Solana RPC (Helius / QuickNode recommended — NOT public RPC)
+SOLANA_RPC_URL=https://mainnet.helius-rpc.com/?api-key=YOUR_API_KEY

--- a/discord-bot/.gitignore
+++ b/discord-bot/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.env
+data/

--- a/discord-bot/README.md
+++ b/discord-bot/README.md
@@ -1,0 +1,167 @@
+# 🥟 Baozi Discord Market Bot
+
+A Discord bot with slash commands and rich embeds that brings [Baozi](https://baozi.bet) prediction market data into Discord servers. Browse markets, see odds, track portfolios — all without leaving Discord.
+
+**Read-only.** No wallet management, no transaction signing. Pure discovery and engagement.
+
+## Features
+
+| Command | Description |
+|---------|-------------|
+| `/markets [category]` | Browse active markets (optional keyword filter: crypto, sports, etc.) |
+| `/odds <marketId>` | Detailed odds embed with progress bars and expected payouts |
+| `/portfolio <wallet>` | View betting positions for any Solana wallet |
+| `/hot` | Highest volume markets ranked by pool size |
+| `/closing` | Markets closing within 24 hours |
+| `/race <marketId>` | Race (multi-outcome) market with all outcome odds |
+| `/setup #channel HH:MM` | Configure daily automated market roundup |
+
+## Rich Embeds
+
+```
+┌─────────────────────────────────────┐
+│ 📊 Will BTC hit $120K by March?     │
+│                                     │
+│ Yes  ████████████░░░  63.2%         │
+│ No   ████████░░░░░░░  36.8%         │
+│                                     │
+│ Pool: 15.2 SOL                      │
+│ Closes: Feb 28, 2026 00:00 UTC      │
+│ 🧪 Lab | 🟢 Active                  │
+└─────────────────────────────────────┘
+```
+
+## Setup
+
+### 1. Create a Discord Bot
+
+1. Go to [Discord Developer Portal](https://discord.com/developers/applications)
+2. Click **New Application** → name it (e.g., "Baozi Markets")
+3. Go to **Bot** tab → Click **Reset Token** → Copy the token
+4. Go to **OAuth2** → Copy the **Application ID**
+5. Under **OAuth2 → URL Generator**:
+   - Scopes: `bot`, `applications.commands`
+   - Bot Permissions: `Send Messages`, `Embed Links`, `Use Slash Commands`
+6. Copy the generated URL and open it to invite the bot to your server
+
+### 2. Configure Environment
+
+```bash
+cd discord-bot
+cp .env.example .env
+```
+
+Edit `.env`:
+```
+DISCORD_TOKEN=your_bot_token_here
+DISCORD_CLIENT_ID=your_application_id_here
+SOLANA_RPC_URL=https://mainnet.helius-rpc.com/?api-key=YOUR_KEY
+```
+
+> **Note:** Use a dedicated Solana RPC provider (Helius, QuickNode, etc.). Public RPC will be rate-limited.
+
+### 3. Install & Register Commands
+
+```bash
+npm install
+npm run register    # Register slash commands with Discord
+```
+
+### 4. Run the Bot
+
+```bash
+# Development (with hot reload)
+npm run dev
+
+# Production
+npm run build
+npm start
+```
+
+## Daily Roundup
+
+Use `/setup #channel 09:00` to configure automatic daily posts:
+- **Top 5 markets** by pool size
+- **Markets closing soon** (within 24h)
+- **Recently resolved** markets with results
+- **Race market** highlights
+
+Time is in **UTC**. Requires **Manage Server** permission.
+
+## Architecture
+
+```
+discord-bot/
+├── src/
+│   ├── index.ts              # Main entry — Discord client + event routing
+│   ├── register-commands.ts  # Slash command registration script
+│   ├── mcp/
+│   │   └── client.ts         # MCP client wrapper → @baozi.bet/mcp-server
+│   ├── commands/
+│   │   ├── markets.ts        # /markets [category]
+│   │   ├── odds.ts           # /odds <marketId>
+│   │   ├── portfolio.ts      # /portfolio <wallet>
+│   │   ├── hot.ts            # /hot
+│   │   ├── closing.ts        # /closing
+│   │   ├── race.ts           # /race <marketId>
+│   │   └── setup.ts          # /setup #channel HH:MM
+│   ├── embeds/
+│   │   ├── helpers.ts        # Progress bars, formatters, colors
+│   │   ├── market.ts         # Boolean market embeds
+│   │   ├── race.ts           # Race market embeds
+│   │   └── portfolio.ts      # Portfolio embeds
+│   └── roundup/
+│       └── scheduler.ts      # Cron-based daily roundup
+├── data/                     # Guild configs (auto-created)
+├── package.json
+├── tsconfig.json
+├── .env.example
+└── .gitignore
+```
+
+## Data Source
+
+All data comes from the **Baozi MCP server** (`@baozi.bet/mcp-server`) which reads directly from **Solana mainnet**. The bot spawns the MCP server as a child process and calls its tools via the MCP protocol:
+
+- `list_markets` — Browse active boolean markets
+- `get_market` — Get market details by public key
+- `get_quote` — Calculate expected payouts
+- `list_race_markets` — Multi-outcome markets
+- `get_race_market` — Race market with all outcomes
+- `get_positions` — Wallet positions
+
+No authentication needed for reads. All data is real mainnet data.
+
+## Deployment (24/7)
+
+### Using PM2
+
+```bash
+npm run build
+npm install -g pm2
+pm2 start dist/index.js --name baozi-bot
+pm2 save
+pm2 startup    # Auto-restart on reboot
+```
+
+### Using Docker
+
+```dockerfile
+FROM node:20-slim
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --production
+COPY dist/ ./dist/
+COPY .env ./
+CMD ["node", "dist/index.js"]
+```
+
+```bash
+npm run build
+docker build -t baozi-bot .
+docker run -d --name baozi-bot --restart always baozi-bot
+```
+
+## License
+
+MIT

--- a/discord-bot/package-lock.json
+++ b/discord-bot/package-lock.json
@@ -1,0 +1,2043 @@
+{
+  "name": "baozi-discord-bot",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "baozi-discord-bot",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0",
+        "discord.js": "^14.16.0",
+        "dotenv": "^17.3.1",
+        "node-cron": "^3.0.3"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "@types/node-cron": "^3.0.11",
+        "tsx": "^4.0.0",
+        "typescript": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@discordjs/builders": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.13.1.tgz",
+      "integrity": "sha512-cOU0UDHc3lp/5nKByDxkmRiNZBpdp0kx55aarbiAfakfKJHlxv/yFW1zmIqCAmwH5CRlrH9iMFKJMpvW4DPB+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/util": "^1.2.0",
+        "@sapphire/shapeshift": "^4.0.0",
+        "discord-api-types": "^0.38.33",
+        "fast-deep-equal": "^3.1.3",
+        "ts-mixer": "^6.0.4",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/collection": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
+      "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.11.0"
+      }
+    },
+    "node_modules/@discordjs/formatters": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.2.tgz",
+      "integrity": "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.0.tgz",
+      "integrity": "sha512-RDYrhmpB7mTvmCKcpj+pc5k7POKszS4E2O9TYc+U+Y4iaCP+r910QdO43qmpOja8LRr1RJ0b3U+CqVsnPqzf4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.1",
+        "@discordjs/util": "^1.1.1",
+        "@sapphire/async-queue": "^1.5.3",
+        "@sapphire/snowflake": "^3.5.3",
+        "@vladfrangu/async_event_emitter": "^2.4.6",
+        "discord-api-types": "^0.38.16",
+        "magic-bytes.js": "^1.10.0",
+        "tslib": "^2.6.3",
+        "undici": "6.21.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/util": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz",
+      "integrity": "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz",
+      "integrity": "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/rest": "^2.5.1",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@types/ws": "^8.5.10",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "^0.38.1",
+        "tslib": "^2.6.2",
+        "ws": "^8.17.0"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
+      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
+      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@sapphire/async-queue": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
+      "integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@sapphire/shapeshift": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
+      "integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=v16"
+      }
+    },
+    "node_modules/@sapphire/snowflake": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
+      "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.33",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
+      "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/node-cron": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/node-cron/-/node-cron-3.0.11.tgz",
+      "integrity": "sha512-0ikrnug3/IyneSHqCBeslAhlK2aBfYek1fGo4bP4QnZPmiqSGRK+Oy7ZMisLWkesffJvQ1cqAcBnJC+8+nxIAg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@vladfrangu/async_event_emitter": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz",
+      "integrity": "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/discord-api-types": {
+      "version": "0.38.39",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.39.tgz",
+      "integrity": "sha512-XRdDQvZvID1XvcFftjSmd4dcmMi/RL/jSy5sduBDAvCGFcNFHThdIQXCEBDZFe52lCNEzuIL0QJoKYAmRmxLUA==",
+      "license": "MIT",
+      "workspaces": [
+        "scripts/actions/documentation"
+      ]
+    },
+    "node_modules/discord.js": {
+      "version": "14.25.1",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.25.1.tgz",
+      "integrity": "sha512-2l0gsPOLPs5t6GFZfQZKnL1OJNYFcuC/ETWsW4VtKVD/tg4ICa9x+jb9bkPffkMdRpRpuUaO/fKkHCBeiCKh8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/builders": "^1.13.0",
+        "@discordjs/collection": "1.5.3",
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/rest": "^2.6.0",
+        "@discordjs/util": "^1.2.0",
+        "@discordjs/ws": "^1.2.3",
+        "@sapphire/snowflake": "3.5.3",
+        "discord-api-types": "^0.38.33",
+        "fast-deep-equal": "3.1.3",
+        "lodash.snakecase": "4.1.1",
+        "magic-bytes.js": "^1.10.0",
+        "tslib": "^2.6.3",
+        "undici": "6.21.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
+      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
+      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.11.9",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
+      "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "license": "MIT"
+    },
+    "node_modules/magic-bytes.js": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz",
+      "integrity": "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==",
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-cron": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
+      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+      "license": "ISC",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/ts-mixer": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
+    }
+  }
+}

--- a/discord-bot/package.json
+++ b/discord-bot/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "baozi-discord-bot",
+  "version": "1.0.0",
+  "description": "Discord bot with slash commands and rich embeds for Baozi prediction markets",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts",
+    "register": "tsx src/register-commands.ts"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "discord.js": "^14.16.0",
+    "dotenv": "^17.3.1",
+    "node-cron": "^3.0.3"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/node-cron": "^3.0.11",
+    "tsx": "^4.0.0",
+    "typescript": "^5.0.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "license": "MIT"
+}

--- a/discord-bot/src/commands/closing.ts
+++ b/discord-bot/src/commands/closing.ts
@@ -1,0 +1,61 @@
+/**
+ * /closing — Markets closing within 24h
+ */
+import { SlashCommandBuilder, ChatInputCommandInteraction } from 'discord.js';
+import { listMarkets, listRaceMarkets } from '../mcp/client.js';
+import { buildMarketListEmbed } from '../embeds/market.js';
+import { buildRaceListEmbed } from '../embeds/race.js';
+import { errorEmbed } from '../embeds/helpers.js';
+
+export const data = new SlashCommandBuilder()
+    .setName('closing')
+    .setDescription('Markets closing within 24 hours');
+
+export async function execute(interaction: ChatInputCommandInteraction) {
+    await interaction.deferReply();
+
+    try {
+        const now = Date.now();
+        const in24h = now + 24 * 60 * 60 * 1000;
+
+        // Boolean markets closing soon
+        const boolMarkets = await listMarkets('Active');
+        const closingBool = boolMarkets
+            .filter((m) => {
+                const closeTime = new Date(m.closingTime).getTime();
+                return closeTime > now && closeTime <= in24h;
+            })
+            .sort((a, b) => new Date(a.closingTime).getTime() - new Date(b.closingTime).getTime());
+
+        // Race markets closing soon
+        const raceMarkets = await listRaceMarkets('Active');
+        const closingRace = raceMarkets
+            .filter((m) => {
+                const closeTime = new Date(m.closingTime).getTime();
+                return closeTime > now && closeTime <= in24h;
+            })
+            .sort((a, b) => new Date(a.closingTime).getTime() - new Date(b.closingTime).getTime());
+
+        const embeds = [];
+
+        if (closingBool.length > 0) {
+            const { embed } = buildMarketListEmbed(closingBool, '⏰ Markets Closing Soon (24h)');
+            embeds.push(embed);
+        }
+
+        if (closingRace.length > 0) {
+            embeds.push(buildRaceListEmbed(closingRace, '🏇 Race Markets Closing Soon'));
+        }
+
+        if (embeds.length === 0) {
+            embeds.push(errorEmbed('No Markets Closing', 'No markets are closing within the next 24 hours.'));
+        }
+
+        await interaction.editReply({ embeds });
+    } catch (err) {
+        console.error('[/closing] Error:', err);
+        await interaction.editReply({
+            embeds: [errorEmbed('Error', 'Failed to fetch market data. Please try again later.')],
+        });
+    }
+}

--- a/discord-bot/src/commands/hot.ts
+++ b/discord-bot/src/commands/hot.ts
@@ -1,0 +1,53 @@
+/**
+ * /hot — Highest volume (pool size) markets in last 24h
+ */
+import { SlashCommandBuilder, ChatInputCommandInteraction } from 'discord.js';
+import { listMarkets, listRaceMarkets } from '../mcp/client.js';
+import { buildMarketListEmbed } from '../embeds/market.js';
+import { buildRaceListEmbed } from '../embeds/race.js';
+import { errorEmbed } from '../embeds/helpers.js';
+
+export const data = new SlashCommandBuilder()
+    .setName('hot')
+    .setDescription('Show the hottest markets by volume');
+
+export async function execute(interaction: ChatInputCommandInteraction) {
+    await interaction.deferReply();
+
+    try {
+        // Fetch all active boolean markets
+        const boolMarkets = await listMarkets('Active');
+        // Sort by total pool (proxy for volume) descending
+        const hotBool = [...boolMarkets]
+            .sort((a, b) => b.totalPoolSol - a.totalPoolSol)
+            .slice(0, 5);
+
+        // Fetch all active race markets
+        const raceMarkets = await listRaceMarkets('Active');
+        const hotRace = [...raceMarkets]
+            .sort((a, b) => b.totalPoolSol - a.totalPoolSol)
+            .slice(0, 3);
+
+        const embeds = [];
+
+        if (hotBool.length > 0) {
+            const { embed } = buildMarketListEmbed(hotBool, '🔥 Hottest Markets by Pool Size');
+            embeds.push(embed);
+        }
+
+        if (hotRace.length > 0) {
+            embeds.push(buildRaceListEmbed(hotRace, '🏇 Hot Race Markets'));
+        }
+
+        if (embeds.length === 0) {
+            embeds.push(errorEmbed('No Markets', 'No active markets at the moment.'));
+        }
+
+        await interaction.editReply({ embeds });
+    } catch (err) {
+        console.error('[/hot] Error:', err);
+        await interaction.editReply({
+            embeds: [errorEmbed('Error', 'Failed to fetch market data. Please try again later.')],
+        });
+    }
+}

--- a/discord-bot/src/commands/markets.ts
+++ b/discord-bot/src/commands/markets.ts
@@ -1,0 +1,86 @@
+/**
+ * /markets [category] — List active markets with optional keyword filter
+ */
+import { SlashCommandBuilder, ChatInputCommandInteraction } from 'discord.js';
+import { listMarkets, listRaceMarkets } from '../mcp/client.js';
+import { buildMarketListEmbed } from '../embeds/market.js';
+import { buildRaceListEmbed } from '../embeds/race.js';
+import { errorEmbed } from '../embeds/helpers.js';
+
+export const data = new SlashCommandBuilder()
+    .setName('markets')
+    .setDescription('Browse active Baozi prediction markets')
+    .addStringOption((opt) =>
+        opt
+            .setName('category')
+            .setDescription('Filter by keyword (e.g., crypto, sports, politics)')
+            .setRequired(false)
+    )
+    .addStringOption((opt) =>
+        opt
+            .setName('layer')
+            .setDescription('Filter by market layer')
+            .setRequired(false)
+            .addChoices(
+                { name: 'Official', value: 'Official' },
+                { name: 'Lab', value: 'Lab' },
+                { name: 'All', value: 'all' }
+            )
+    );
+
+export async function execute(interaction: ChatInputCommandInteraction) {
+    await interaction.deferReply();
+
+    try {
+        const category = interaction.options.getString('category')?.toLowerCase();
+        const layer = interaction.options.getString('layer');
+
+        // Fetch boolean markets
+        let boolMarkets = await listMarkets('Active', layer && layer !== 'all' ? layer : undefined);
+
+        // Filter by category keyword if provided
+        if (category) {
+            boolMarkets = boolMarkets.filter((m) =>
+                m.question.toLowerCase().includes(category)
+            );
+        }
+
+        // Fetch race markets
+        let raceMarkets = await listRaceMarkets('Active');
+        if (category) {
+            raceMarkets = raceMarkets.filter((m) =>
+                m.question.toLowerCase().includes(category)
+            );
+        }
+
+        const title = category
+            ? `📊 Active Markets — "${category}"`
+            : '📊 Active Prediction Markets';
+
+        const embeds = [];
+
+        if (boolMarkets.length > 0) {
+            const { embed } = buildMarketListEmbed(boolMarkets, title);
+            embeds.push(embed);
+        }
+
+        if (raceMarkets.length > 0) {
+            embeds.push(buildRaceListEmbed(raceMarkets, '🏇 Active Race Markets'));
+        }
+
+        if (embeds.length === 0) {
+            embeds.push(
+                errorEmbed('No Markets Found', category
+                    ? `No active markets matching "${category}". Try \`/markets\` without a filter.`
+                    : 'No active markets at the moment. Check back later!')
+            );
+        }
+
+        await interaction.editReply({ embeds });
+    } catch (err) {
+        console.error('[/markets] Error:', err);
+        await interaction.editReply({
+            embeds: [errorEmbed('Error', 'Failed to fetch markets. Please try again later.')],
+        });
+    }
+}

--- a/discord-bot/src/commands/odds.ts
+++ b/discord-bot/src/commands/odds.ts
@@ -1,0 +1,69 @@
+/**
+ * /odds <marketId> — Detailed odds embed for a boolean market
+ */
+import { SlashCommandBuilder, ChatInputCommandInteraction } from 'discord.js';
+import { getMarket, getQuote } from '../mcp/client.js';
+import { buildMarketEmbed, buildMarketButtons } from '../embeds/market.js';
+import { errorEmbed } from '../embeds/helpers.js';
+
+export const data = new SlashCommandBuilder()
+    .setName('odds')
+    .setDescription('Get detailed odds for a specific market')
+    .addStringOption((opt) =>
+        opt
+            .setName('market_id')
+            .setDescription('Market public key (Solana address)')
+            .setRequired(true)
+    );
+
+export async function execute(interaction: ChatInputCommandInteraction) {
+    await interaction.deferReply();
+
+    try {
+        const marketId = interaction.options.getString('market_id', true).trim();
+
+        const market = await getMarket(marketId);
+        if (!market) {
+            await interaction.editReply({
+                embeds: [errorEmbed('Market Not Found', `No market found with ID \`${marketId}\`. Make sure you're using the full Solana public key.`)],
+            });
+            return;
+        }
+
+        const embed = buildMarketEmbed(market);
+
+        // Try to get a quote to show expected payouts
+        if (market.isBettingOpen && market.totalPoolSol > 0) {
+            try {
+                const quoteYes = await getQuote(marketId, 'Yes', 1.0);
+                const quoteNo = await getQuote(marketId, 'No', 1.0);
+
+                const payoutLines: string[] = [];
+                if (quoteYes && typeof quoteYes === 'object' && 'expectedPayout' in quoteYes) {
+                    payoutLines.push(`Yes → ${(quoteYes as any).expectedPayout.toFixed(2)} SOL`);
+                }
+                if (quoteNo && typeof quoteNo === 'object' && 'expectedPayout' in quoteNo) {
+                    payoutLines.push(`No → ${(quoteNo as any).expectedPayout.toFixed(2)} SOL`);
+                }
+
+                if (payoutLines.length > 0) {
+                    embed.addFields({
+                        name: '💡 Expected Payout (1 SOL bet)',
+                        value: payoutLines.join('\n'),
+                        inline: false,
+                    });
+                }
+            } catch {
+                // Quote not available — that's fine
+            }
+        }
+
+        const row = buildMarketButtons(marketId);
+        await interaction.editReply({ embeds: [embed], components: [row] });
+    } catch (err) {
+        console.error('[/odds] Error:', err);
+        await interaction.editReply({
+            embeds: [errorEmbed('Error', 'Failed to fetch market data. Please try again later.')],
+        });
+    }
+}

--- a/discord-bot/src/commands/portfolio.ts
+++ b/discord-bot/src/commands/portfolio.ts
@@ -1,0 +1,49 @@
+/**
+ * /portfolio <wallet> — View positions for a Solana wallet
+ */
+import { SlashCommandBuilder, ChatInputCommandInteraction } from 'discord.js';
+import { getPositions } from '../mcp/client.js';
+import { buildPortfolioEmbed } from '../embeds/portfolio.js';
+import { errorEmbed } from '../embeds/helpers.js';
+
+export const data = new SlashCommandBuilder()
+    .setName('portfolio')
+    .setDescription('View betting positions for a Solana wallet')
+    .addStringOption((opt) =>
+        opt
+            .setName('wallet')
+            .setDescription('Solana wallet address')
+            .setRequired(true)
+    );
+
+export async function execute(interaction: ChatInputCommandInteraction) {
+    await interaction.deferReply();
+
+    try {
+        const wallet = interaction.options.getString('wallet', true).trim();
+
+        // Basic validation
+        if (wallet.length < 32 || wallet.length > 44) {
+            await interaction.editReply({
+                embeds: [errorEmbed('Invalid Wallet', 'Please provide a valid Solana wallet address (32-44 characters).')],
+            });
+            return;
+        }
+
+        const positions = await getPositions(wallet);
+        if (!positions) {
+            await interaction.editReply({
+                embeds: [errorEmbed('No Data', `No positions found for wallet \`${wallet}\`. The wallet may have no Baozi bets.`)],
+            });
+            return;
+        }
+
+        const embed = buildPortfolioEmbed(positions);
+        await interaction.editReply({ embeds: [embed] });
+    } catch (err) {
+        console.error('[/portfolio] Error:', err);
+        await interaction.editReply({
+            embeds: [errorEmbed('Error', 'Failed to fetch portfolio data. Please try again later.')],
+        });
+    }
+}

--- a/discord-bot/src/commands/race.ts
+++ b/discord-bot/src/commands/race.ts
@@ -1,0 +1,50 @@
+/**
+ * /race <marketId> — Race market with all outcome odds
+ */
+import { SlashCommandBuilder, ChatInputCommandInteraction, ActionRowBuilder, ButtonBuilder, ButtonStyle } from 'discord.js';
+import { getRaceMarket } from '../mcp/client.js';
+import { buildRaceEmbed } from '../embeds/race.js';
+import { errorEmbed, marketUrl } from '../embeds/helpers.js';
+
+export const data = new SlashCommandBuilder()
+    .setName('race')
+    .setDescription('Get detailed odds for a race (multi-outcome) market')
+    .addStringOption((opt) =>
+        opt
+            .setName('market_id')
+            .setDescription('Race market public key (Solana address)')
+            .setRequired(true)
+    );
+
+export async function execute(interaction: ChatInputCommandInteraction) {
+    await interaction.deferReply();
+
+    try {
+        const marketId = interaction.options.getString('market_id', true).trim();
+
+        const race = await getRaceMarket(marketId);
+        if (!race) {
+            await interaction.editReply({
+                embeds: [errorEmbed('Race Market Not Found', `No race market found with ID \`${marketId}\`. Make sure you're using the full Solana public key.`)],
+            });
+            return;
+        }
+
+        const embed = buildRaceEmbed(race);
+
+        const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+            new ButtonBuilder()
+                .setLabel('View on Baozi')
+                .setStyle(ButtonStyle.Link)
+                .setURL(marketUrl(marketId))
+                .setEmoji('🔗')
+        );
+
+        await interaction.editReply({ embeds: [embed], components: [row] });
+    } catch (err) {
+        console.error('[/race] Error:', err);
+        await interaction.editReply({
+            embeds: [errorEmbed('Error', 'Failed to fetch race market data. Please try again later.')],
+        });
+    }
+}

--- a/discord-bot/src/commands/setup.ts
+++ b/discord-bot/src/commands/setup.ts
@@ -1,0 +1,93 @@
+/**
+ * /setup #channel HH:MM — Configure daily roundup
+ */
+import { SlashCommandBuilder, ChatInputCommandInteraction, PermissionFlagsBits, ChannelType } from 'discord.js';
+import { loadGuildConfig, saveGuildConfig } from '../roundup/scheduler.js';
+import { errorEmbed, EMBED_COLORS, baoziFooter } from '../embeds/helpers.js';
+import { EmbedBuilder } from 'discord.js';
+
+export const data = new SlashCommandBuilder()
+    .setName('setup')
+    .setDescription('Configure daily market roundup for this server')
+    .addChannelOption((opt) =>
+        opt
+            .setName('channel')
+            .setDescription('Channel to post daily roundup in')
+            .addChannelTypes(ChannelType.GuildText)
+            .setRequired(true)
+    )
+    .addStringOption((opt) =>
+        opt
+            .setName('time')
+            .setDescription('Time to post (HH:MM in UTC, e.g., 09:00)')
+            .setRequired(true)
+    )
+    .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild);
+
+export async function execute(interaction: ChatInputCommandInteraction) {
+    await interaction.deferReply({ ephemeral: true });
+
+    try {
+        const channel = interaction.options.getChannel('channel', true);
+        const timeStr = interaction.options.getString('time', true).trim();
+
+        // Validate time format
+        const timeMatch = timeStr.match(/^(\d{1,2}):(\d{2})$/);
+        if (!timeMatch) {
+            await interaction.editReply({
+                embeds: [errorEmbed('Invalid Time', 'Please use HH:MM format (e.g., 09:00, 14:30). Time is in UTC.')],
+            });
+            return;
+        }
+
+        const hour = parseInt(timeMatch[1], 10);
+        const minute = parseInt(timeMatch[2], 10);
+        if (hour < 0 || hour > 23 || minute < 0 || minute > 59) {
+            await interaction.editReply({
+                embeds: [errorEmbed('Invalid Time', 'Hour must be 0-23 and minute must be 0-59.')],
+            });
+            return;
+        }
+
+        const guildId = interaction.guildId;
+        if (!guildId) {
+            await interaction.editReply({
+                embeds: [errorEmbed('Error', 'This command can only be used in a server.')],
+            });
+            return;
+        }
+
+        // Save config
+        const config = loadGuildConfig();
+        config[guildId] = {
+            channelId: channel.id,
+            hour,
+            minute,
+            enabled: true,
+        };
+        saveGuildConfig(config);
+
+        const timeFormatted = `${hour.toString().padStart(2, '0')}:${minute.toString().padStart(2, '0')}`;
+
+        const embed = new EmbedBuilder()
+            .setColor(EMBED_COLORS.SUCCESS)
+            .setTitle('✅ Daily Roundup Configured')
+            .setDescription(
+                [
+                    `**Channel:** <#${channel.id}>`,
+                    `**Time:** ${timeFormatted} UTC`,
+                    '',
+                    'A daily summary of top markets, new markets, and resolved markets will be posted automatically.',
+                ].join('\n')
+            )
+            .setFooter(baoziFooter())
+            .setTimestamp();
+
+        await interaction.editReply({ embeds: [embed] });
+    } catch (err) {
+        console.error('[/setup] Error:', err);
+        await interaction.editReply({
+            embeds: [errorEmbed('Error', 'Failed to save configuration. Please try again.')],
+        });
+    }
+}

--- a/discord-bot/src/embeds/helpers.ts
+++ b/discord-bot/src/embeds/helpers.ts
@@ -148,3 +148,12 @@ export function errorEmbed(title: string, description: string): EmbedBuilder {
 export function baoziFooter(): { text: string; iconURL?: string } {
     return { text: 'Baozi.bet • Prediction Markets on Solana' };
 }
+
+/**
+ * Guard against Discord's 4096-char embed description limit.
+ * Truncates with an overflow message if needed.
+ */
+export function safeDescription(text: string, maxLen = 4000): string {
+    if (text.length <= maxLen) return text;
+    return text.slice(0, maxLen) + '\n\n_…truncated — use specific commands for details_';
+}

--- a/discord-bot/src/embeds/helpers.ts
+++ b/discord-bot/src/embeds/helpers.ts
@@ -1,0 +1,150 @@
+/**
+ * Embed Helper Utilities
+ * Progress bars, formatters, and shared embed styles.
+ */
+import { EmbedBuilder, Colors } from 'discord.js';
+
+// ─── Progress Bar ────────────────────────────────────────────────────────────
+
+const BAR_FILLED = '█';
+const BAR_EMPTY = '░';
+const BAR_LENGTH = 15;
+
+/**
+ * Create a unicode block progress bar.
+ * @param percent 0-100
+ */
+export function progressBar(percent: number): string {
+    const clamped = Math.max(0, Math.min(100, percent));
+    const filled = Math.round((clamped / 100) * BAR_LENGTH);
+    const empty = BAR_LENGTH - filled;
+    return BAR_FILLED.repeat(filled) + BAR_EMPTY.repeat(empty);
+}
+
+// ─── Formatters ──────────────────────────────────────────────────────────────
+
+/**
+ * Format SOL amount with symbol
+ */
+export function formatSol(amount: number): string {
+    if (amount >= 1000) return `${(amount / 1000).toFixed(1)}K SOL`;
+    if (amount >= 1) return `${amount.toFixed(2)} SOL`;
+    return `${amount.toFixed(4)} SOL`;
+}
+
+/**
+ * Format ISO date to human-readable relative time
+ */
+export function formatTime(isoDate: string): string {
+    const date = new Date(isoDate);
+    const now = new Date();
+    const diffMs = date.getTime() - now.getTime();
+    const diffHours = diffMs / (1000 * 60 * 60);
+    const diffDays = diffMs / (1000 * 60 * 60 * 24);
+
+    if (diffMs < 0) {
+        // Past
+        const absDays = Math.abs(diffDays);
+        if (absDays < 1) return `${Math.abs(Math.round(diffHours))}h ago`;
+        return `${Math.round(absDays)}d ago`;
+    }
+
+    if (diffHours < 1) return `${Math.round(diffMs / 60000)}m`;
+    if (diffHours < 24) return `${Math.round(diffHours)}h`;
+    if (diffDays < 7) return `${Math.round(diffDays)}d`;
+    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+/**
+ * Format ISO date to absolute display
+ */
+export function formatDate(isoDate: string): string {
+    const date = new Date(isoDate);
+    return date.toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+        timeZone: 'UTC',
+        timeZoneName: 'short',
+    });
+}
+
+/**
+ * Truncate text to a maximum length
+ */
+export function truncate(text: string, maxLen: number): string {
+    if (text.length <= maxLen) return text;
+    return text.slice(0, maxLen - 1) + '…';
+}
+
+/**
+ * Shorten a Solana public key for display
+ */
+export function shortKey(key: string): string {
+    if (key.length <= 12) return key;
+    return `${key.slice(0, 4)}…${key.slice(-4)}`;
+}
+
+/**
+ * Get the Baozi market URL
+ */
+export function marketUrl(publicKey: string): string {
+    return `https://baozi.bet/market/${publicKey}`;
+}
+
+/**
+ * Status emoji
+ */
+export function statusEmoji(status: string): string {
+    switch (status.toLowerCase()) {
+        case 'active': return '🟢';
+        case 'closed': return '🔴';
+        case 'resolved': return '✅';
+        case 'cancelled': return '❌';
+        case 'paused': return '⏸️';
+        default: return '⚪';
+    }
+}
+
+/**
+ * Layer emoji + label
+ */
+export function layerLabel(layer: string): string {
+    switch (layer.toLowerCase()) {
+        case 'official': return '🏛️ Official';
+        case 'lab': return '🧪 Lab';
+        case 'private': return '🔒 Private';
+        default: return layer;
+    }
+}
+
+// ─── Embed Colors ────────────────────────────────────────────────────────────
+
+export const EMBED_COLORS = {
+    PRIMARY: 0x7c3aed,    // Purple (Baozi brand)
+    SUCCESS: 0x10b981,    // Green
+    WARNING: 0xf59e0b,    // Amber
+    ERROR: 0xef4444,      // Red
+    INFO: 0x3b82f6,       // Blue
+    RACE: 0xec4899,       // Pink
+} as const;
+
+/**
+ * Create a standard error embed
+ */
+export function errorEmbed(title: string, description: string): EmbedBuilder {
+    return new EmbedBuilder()
+        .setColor(EMBED_COLORS.ERROR)
+        .setTitle(`❌ ${title}`)
+        .setDescription(description)
+        .setTimestamp();
+}
+
+/**
+ * Footer stamp for all embeds
+ */
+export function baoziFooter(): { text: string; iconURL?: string } {
+    return { text: 'Baozi.bet • Prediction Markets on Solana' };
+}

--- a/discord-bot/src/embeds/market.ts
+++ b/discord-bot/src/embeds/market.ts
@@ -1,0 +1,105 @@
+/**
+ * Market Embed Builders
+ * Rich embeds for boolean (YES/NO) markets.
+ */
+import { EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } from 'discord.js';
+import type { BooleanMarket } from '../mcp/client.js';
+import {
+    progressBar,
+    formatSol,
+    formatDate,
+    formatTime,
+    truncate,
+    marketUrl,
+    statusEmoji,
+    layerLabel,
+    baoziFooter,
+    EMBED_COLORS,
+} from './helpers.js';
+
+/**
+ * Build a detailed embed for a single boolean market
+ */
+export function buildMarketEmbed(market: BooleanMarket): EmbedBuilder {
+    const yesBar = progressBar(market.yesPercent);
+    const noBar = progressBar(market.noPercent);
+
+    const embed = new EmbedBuilder()
+        .setColor(market.status === 'Active' ? EMBED_COLORS.PRIMARY : EMBED_COLORS.WARNING)
+        .setTitle(`📊 ${truncate(market.question, 200)}`)
+        .setURL(marketUrl(market.publicKey))
+        .setDescription(
+            [
+                `**Yes**  ${yesBar}  ${market.yesPercent.toFixed(1)}%`,
+                `**No**   ${noBar}  ${market.noPercent.toFixed(1)}%`,
+                '',
+                `💰 **Pool:** ${formatSol(market.totalPoolSol)}`,
+                `📅 **Closes:** ${formatDate(market.closingTime)}`,
+                `${layerLabel(market.layer)} | ${statusEmoji(market.status)} ${market.status}`,
+            ].join('\n')
+        )
+        .setFooter(baoziFooter())
+        .setTimestamp();
+
+    if (market.winningOutcome) {
+        embed.addFields({ name: '🏆 Result', value: market.winningOutcome, inline: true });
+    }
+
+    return embed;
+}
+
+/**
+ * Build an embed for a list of markets (paginated style)
+ */
+export function buildMarketListEmbed(
+    markets: BooleanMarket[],
+    title: string,
+    page: number = 0,
+    pageSize: number = 5
+): { embed: EmbedBuilder; totalPages: number } {
+    const totalPages = Math.max(1, Math.ceil(markets.length / pageSize));
+    const start = page * pageSize;
+    const pageMarkets = markets.slice(start, start + pageSize);
+
+    const lines: string[] = [];
+    for (const m of pageMarkets) {
+        const yesBar = progressBar(m.yesPercent);
+        const timeLeft = formatTime(m.closingTime);
+        lines.push(
+            [
+                `**${truncate(m.question, 60)}**`,
+                `Yes ${yesBar} ${m.yesPercent.toFixed(1)}% | Pool: ${formatSol(m.totalPoolSol)} | ⏰ ${timeLeft}`,
+                `[View](${marketUrl(m.publicKey)}) • ID: \`${m.publicKey.slice(0, 8)}…\``,
+                '',
+            ].join('\n')
+        );
+    }
+
+    const embed = new EmbedBuilder()
+        .setColor(EMBED_COLORS.PRIMARY)
+        .setTitle(title)
+        .setDescription(
+            lines.length > 0
+                ? lines.join('\n')
+                : '_No markets found._'
+        )
+        .setFooter({
+            text: `${baoziFooter().text} • Page ${page + 1}/${totalPages} • ${markets.length} markets`,
+        })
+        .setTimestamp();
+
+    return { embed, totalPages };
+}
+
+/**
+ * Build action row with View on Baozi button
+ */
+export function buildMarketButtons(publicKey: string): ActionRowBuilder<ButtonBuilder> {
+    return new ActionRowBuilder<ButtonBuilder>().addComponents(
+        new ButtonBuilder()
+            .setLabel('View on Baozi')
+            .setStyle(ButtonStyle.Link)
+            .setURL(marketUrl(publicKey))
+            .setEmoji('🔗')
+    );
+}

--- a/discord-bot/src/embeds/market.ts
+++ b/discord-bot/src/embeds/market.ts
@@ -14,6 +14,7 @@ import {
     statusEmoji,
     layerLabel,
     baoziFooter,
+    safeDescription,
     EMBED_COLORS,
 } from './helpers.js';
 
@@ -80,7 +81,7 @@ export function buildMarketListEmbed(
         .setTitle(title)
         .setDescription(
             lines.length > 0
-                ? lines.join('\n')
+                ? safeDescription(lines.join('\n'))
                 : '_No markets found._'
         )
         .setFooter({

--- a/discord-bot/src/embeds/portfolio.ts
+++ b/discord-bot/src/embeds/portfolio.ts
@@ -1,0 +1,55 @@
+/**
+ * Portfolio Embed Builder
+ * Displays wallet positions with P&L summary.
+ */
+import { EmbedBuilder } from 'discord.js';
+import type { PositionsSummary, Position } from '../mcp/client.js';
+import {
+    formatSol,
+    truncate,
+    shortKey,
+    statusEmoji,
+    marketUrl,
+    baoziFooter,
+    EMBED_COLORS,
+} from './helpers.js';
+
+/**
+ * Build a portfolio embed showing all positions for a wallet
+ */
+export function buildPortfolioEmbed(data: PositionsSummary): EmbedBuilder {
+    const lines: string[] = [];
+
+    if (data.positions.length === 0) {
+        lines.push('_No positions found for this wallet._');
+    } else {
+        const toShow = data.positions.slice(0, 10);
+        for (const pos of toShow) {
+            const emoji = pos.claimable ? '💸' : statusEmoji(pos.status);
+            lines.push(
+                [
+                    `${emoji} **${truncate(pos.question || `Market ${shortKey(pos.market)}`, 50)}**`,
+                    `Side: **${pos.side}** | Bet: ${formatSol(pos.amountSol)}${pos.claimable ? ' | **Claimable!**' : ''}`,
+                ].join('\n')
+            );
+        }
+
+        if (data.positions.length > 10) {
+            lines.push(`\n_…and ${data.positions.length - 10} more positions_`);
+        }
+    }
+
+    const embed = new EmbedBuilder()
+        .setColor(EMBED_COLORS.INFO)
+        .setTitle(`👛 Portfolio: ${shortKey(data.wallet)}`)
+        .setDescription(lines.join('\n\n'))
+        .addFields(
+            { name: '📊 Total Positions', value: `${data.totalPositions}`, inline: true },
+            { name: '🟢 Active', value: `${data.activePositions}`, inline: true },
+            { name: '💰 Total Invested', value: formatSol(data.totalInvested), inline: true }
+        )
+        .setFooter(baoziFooter())
+        .setTimestamp();
+
+    return embed;
+}

--- a/discord-bot/src/embeds/portfolio.ts
+++ b/discord-bot/src/embeds/portfolio.ts
@@ -25,11 +25,11 @@ export function buildPortfolioEmbed(data: PositionsSummary): EmbedBuilder {
     } else {
         const toShow = data.positions.slice(0, 10);
         for (const pos of toShow) {
-            const emoji = pos.claimable ? '💸' : statusEmoji(pos.status);
+            const emoji = pos.claimed ? '💸' : statusEmoji(pos.status);
             lines.push(
                 [
-                    `${emoji} **${truncate(pos.question || `Market ${shortKey(pos.market)}`, 50)}**`,
-                    `Side: **${pos.side}** | Bet: ${formatSol(pos.amountSol)}${pos.claimable ? ' | **Claimable!**' : ''}`,
+                    `${emoji} **${truncate(pos.marketQuestion || `Market ${shortKey(pos.publicKey)}`, 50)}**`,
+                    `Side: **${pos.side}** | Bet: ${formatSol(pos.totalAmountSol)}${pos.claimed ? ' | **Claimed**' : ''}`,
                 ].join('\n')
             );
         }
@@ -46,7 +46,7 @@ export function buildPortfolioEmbed(data: PositionsSummary): EmbedBuilder {
         .addFields(
             { name: '📊 Total Positions', value: `${data.totalPositions}`, inline: true },
             { name: '🟢 Active', value: `${data.activePositions}`, inline: true },
-            { name: '💰 Total Invested', value: formatSol(data.totalInvested), inline: true }
+            { name: '💰 Total Bet', value: formatSol(data.totalBetSol), inline: true }
         )
         .setFooter(baoziFooter())
         .setTimestamp();

--- a/discord-bot/src/embeds/race.ts
+++ b/discord-bot/src/embeds/race.ts
@@ -13,6 +13,7 @@ import {
     statusEmoji,
     layerLabel,
     baoziFooter,
+    safeDescription,
     EMBED_COLORS,
 } from './helpers.js';
 
@@ -74,7 +75,7 @@ export function buildRaceListEmbed(
     return new EmbedBuilder()
         .setColor(EMBED_COLORS.RACE)
         .setTitle(title)
-        .setDescription(lines.length > 0 ? lines.join('\n') : '_No race markets found._')
+        .setDescription(lines.length > 0 ? safeDescription(lines.join('\n')) : '_No race markets found._')
         .setFooter(baoziFooter())
         .setTimestamp();
 }

--- a/discord-bot/src/embeds/race.ts
+++ b/discord-bot/src/embeds/race.ts
@@ -1,0 +1,80 @@
+/**
+ * Race Market Embed Builder
+ * Multi-outcome display with all odds.
+ */
+import { EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } from 'discord.js';
+import type { RaceMarket } from '../mcp/client.js';
+import {
+    progressBar,
+    formatSol,
+    formatDate,
+    truncate,
+    marketUrl,
+    statusEmoji,
+    layerLabel,
+    baoziFooter,
+    EMBED_COLORS,
+} from './helpers.js';
+
+/**
+ * Build a detailed embed for a race (multi-outcome) market
+ */
+export function buildRaceEmbed(race: RaceMarket): EmbedBuilder {
+    const outcomeLines: string[] = [];
+
+    // Sort outcomes by percent descending for ranking
+    const sorted = [...race.outcomes].sort((a, b) => b.percent - a.percent);
+
+    for (const outcome of sorted) {
+        const bar = progressBar(outcome.percent);
+        outcomeLines.push(`**${outcome.label}**  ${bar}  ${outcome.percent.toFixed(1)}%`);
+    }
+
+    const embed = new EmbedBuilder()
+        .setColor(EMBED_COLORS.RACE)
+        .setTitle(`🏇 ${truncate(race.question, 200)}`)
+        .setURL(marketUrl(race.publicKey))
+        .setDescription(
+            [
+                ...outcomeLines,
+                '',
+                `💰 **Pool:** ${formatSol(race.totalPoolSol)} | **${race.outcomes.length} outcomes**`,
+                `📅 **Closes:** ${formatDate(race.closingTime)}`,
+                `${layerLabel(race.layer)} | ${statusEmoji(race.status)} ${race.status}`,
+            ].join('\n')
+        )
+        .setFooter(baoziFooter())
+        .setTimestamp();
+
+    return embed;
+}
+
+/**
+ * Build a list embed for multiple race markets
+ */
+export function buildRaceListEmbed(
+    markets: RaceMarket[],
+    title: string
+): EmbedBuilder {
+    const lines: string[] = [];
+    const toShow = markets.slice(0, 5);
+
+    for (const m of toShow) {
+        const topOutcome = [...m.outcomes].sort((a, b) => b.percent - a.percent)[0];
+        lines.push(
+            [
+                `**${truncate(m.question, 60)}**`,
+                `🥇 ${topOutcome?.label || '?'} (${topOutcome?.percent.toFixed(1) || '?'}%) | Pool: ${formatSol(m.totalPoolSol)} | ${m.outcomes.length} outcomes`,
+                `[View](${marketUrl(m.publicKey)})`,
+                '',
+            ].join('\n')
+        );
+    }
+
+    return new EmbedBuilder()
+        .setColor(EMBED_COLORS.RACE)
+        .setTitle(title)
+        .setDescription(lines.length > 0 ? lines.join('\n') : '_No race markets found._')
+        .setFooter(baoziFooter())
+        .setTimestamp();
+}

--- a/discord-bot/src/index.ts
+++ b/discord-bot/src/index.ts
@@ -1,0 +1,130 @@
+/**
+ * Baozi Discord Market Bot
+ * Main entry point — Discord.js client setup, event handlers, slash routing.
+ */
+import {
+    Client,
+    GatewayIntentBits,
+    Events,
+    ChatInputCommandInteraction,
+    Collection,
+} from 'discord.js';
+import * as dotenv from 'dotenv';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { disconnect } from './mcp/client.js';
+import { startScheduler, reloadScheduler } from './roundup/scheduler.js';
+
+// ─── Load .env ──────────────────────────────────────────────────────────────
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+dotenv.config({ path: path.join(__dirname, '..', '.env') });
+
+// ─── Import Commands ─────────────────────────────────────────────────────────
+
+import * as marketsCmd from './commands/markets.js';
+import * as oddsCmd from './commands/odds.js';
+import * as portfolioCmd from './commands/portfolio.js';
+import * as hotCmd from './commands/hot.js';
+import * as closingCmd from './commands/closing.js';
+import * as raceCmd from './commands/race.js';
+import * as setupCmd from './commands/setup.js';
+
+// ─── Command Registry ───────────────────────────────────────────────────────
+
+interface Command {
+    data: { name: string };
+    execute: (interaction: ChatInputCommandInteraction) => Promise<void>;
+}
+
+const commands = new Collection<string, Command>();
+const allCommands: Command[] = [
+    marketsCmd,
+    oddsCmd,
+    portfolioCmd,
+    hotCmd,
+    closingCmd,
+    raceCmd,
+    setupCmd,
+];
+
+for (const cmd of allCommands) {
+    commands.set(cmd.data.name, cmd);
+}
+
+// ─── Discord Client ─────────────────────────────────────────────────────────
+
+const client = new Client({
+    intents: [GatewayIntentBits.Guilds],
+});
+
+// ─── Event: Ready ────────────────────────────────────────────────────────────
+
+client.once(Events.ClientReady, (readyClient) => {
+    console.log('');
+    console.log('='.repeat(60));
+    console.log(`  🥟 Baozi Discord Market Bot`);
+    console.log(`  Logged in as ${readyClient.user.tag}`);
+    console.log(`  Serving ${readyClient.guilds.cache.size} server(s)`);
+    console.log('='.repeat(60));
+    console.log('');
+
+    // Start daily roundup scheduler
+    startScheduler(client);
+});
+
+// ─── Event: Interaction ──────────────────────────────────────────────────────
+
+client.on(Events.InteractionCreate, async (interaction) => {
+    if (!interaction.isChatInputCommand()) return;
+
+    const command = commands.get(interaction.commandName);
+    if (!command) {
+        console.warn(`[Bot] Unknown command: /${interaction.commandName}`);
+        return;
+    }
+
+    try {
+        console.log(
+            `[Bot] /${interaction.commandName} by ${interaction.user.tag} in ${interaction.guild?.name || 'DM'}`
+        );
+        await command.execute(interaction);
+
+        // If setup was used, reload the scheduler
+        if (interaction.commandName === 'setup') {
+            reloadScheduler(client);
+        }
+    } catch (err) {
+        console.error(`[Bot] Error in /${interaction.commandName}:`, err);
+
+        const errorMsg = { content: '❌ Something went wrong. Please try again.', ephemeral: true };
+        if (interaction.replied || interaction.deferred) {
+            await interaction.followUp(errorMsg).catch(() => { });
+        } else {
+            await interaction.reply(errorMsg).catch(() => { });
+        }
+    }
+});
+
+// ─── Graceful Shutdown ───────────────────────────────────────────────────────
+
+async function shutdown() {
+    console.log('\n[Bot] Shutting down...');
+    await disconnect();
+    client.destroy();
+    process.exit(0);
+}
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);
+
+// ─── Start ───────────────────────────────────────────────────────────────────
+
+const TOKEN = process.env.DISCORD_TOKEN;
+if (!TOKEN) {
+    console.error('Missing DISCORD_TOKEN in .env file');
+    console.error('Copy .env.example to .env and fill in your credentials.');
+    process.exit(1);
+}
+
+client.login(TOKEN);

--- a/discord-bot/src/mcp/client.ts
+++ b/discord-bot/src/mcp/client.ts
@@ -1,0 +1,223 @@
+/**
+ * MCP Client Wrapper
+ * Spawns @baozi.bet/mcp-server as a child process and calls tools via MCP protocol.
+ */
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+let client: Client | null = null;
+let transport: StdioClientTransport | null = null;
+let connecting = false;
+
+/**
+ * Get or create the MCP client connection
+ */
+async function getClient(): Promise<Client> {
+    if (client) return client;
+    if (connecting) {
+        // Wait for in-progress connection
+        while (connecting) {
+            await new Promise((r) => setTimeout(r, 100));
+        }
+        if (client) return client;
+    }
+
+    connecting = true;
+    try {
+        const env: Record<string, string> = { ...process.env as Record<string, string> };
+        if (process.env.SOLANA_RPC_URL) {
+            env.SOLANA_RPC_URL = process.env.SOLANA_RPC_URL;
+            env.HELIUS_RPC_URL = process.env.SOLANA_RPC_URL;
+        }
+
+        transport = new StdioClientTransport({
+            command: 'npx',
+            args: ['@baozi.bet/mcp-server'],
+            env,
+        });
+
+        client = new Client({ name: 'baozi-discord-bot', version: '1.0.0' }, { capabilities: {} });
+        await client.connect(transport);
+        console.log('[MCP] Connected to @baozi.bet/mcp-server');
+        return client;
+    } catch (err) {
+        client = null;
+        transport = null;
+        throw err;
+    } finally {
+        connecting = false;
+    }
+}
+
+/**
+ * Call an MCP tool and return the parsed result
+ */
+async function callTool(name: string, args: Record<string, unknown> = {}): Promise<unknown> {
+    const c = await getClient();
+    const result = await c.callTool({ name, arguments: args });
+
+    // MCP returns content array; parse first text block
+    if (result.content && Array.isArray(result.content)) {
+        const textBlock = result.content.find((b: any) => b.type === 'text');
+        if (textBlock && 'text' in textBlock) {
+            try {
+                return JSON.parse(textBlock.text as string);
+            } catch {
+                return textBlock.text;
+            }
+        }
+    }
+    return result;
+}
+
+// ─── Typed Wrappers ──────────────────────────────────────────────────────────
+
+export interface BooleanMarket {
+    publicKey: string;
+    marketId: string;
+    question: string;
+    closingTime: string;
+    resolutionTime: string;
+    status: string;
+    statusCode: number;
+    winningOutcome: string | null;
+    currencyType: string;
+    yesPoolSol: number;
+    noPoolSol: number;
+    totalPoolSol: number;
+    yesPercent: number;
+    noPercent: number;
+    platformFeeBps: number;
+    layer: string;
+    layerCode: number;
+    accessGate: string;
+    creator: string;
+    hasBets: boolean;
+    isBettingOpen: boolean;
+    creatorFeeBps: number;
+}
+
+export interface RaceMarket {
+    publicKey: string;
+    marketId: string;
+    question: string;
+    closingTime: string;
+    resolutionTime: string;
+    status: string;
+    totalPoolSol: number;
+    outcomes: { label: string; poolSol: number; percent: number }[];
+    layer: string;
+    creator: string;
+    isBettingOpen: boolean;
+}
+
+export interface Position {
+    marketId: string;
+    market: string;
+    question: string;
+    side: string;
+    amountSol: number;
+    status: string;
+    winningOutcome: string | null;
+    claimable: boolean;
+}
+
+export interface PositionsSummary {
+    wallet: string;
+    totalPositions: number;
+    activePositions: number;
+    totalInvested: number;
+    positions: Position[];
+}
+
+export interface QuoteResult {
+    market: string;
+    side: string;
+    betAmount: number;
+    currentOdds: { yes: number; no: number };
+    expectedPayout: number;
+    profit: number;
+    newOdds: { yes: number; no: number };
+    platformFee: number;
+}
+
+/**
+ * List all boolean markets, optionally filtered by status
+ */
+export async function listMarkets(status?: string, layer?: string): Promise<BooleanMarket[]> {
+    const args: Record<string, unknown> = {};
+    if (status) args.status = status;
+    if (layer) args.layer = layer;
+    const result = await callTool('list_markets', args);
+    if (Array.isArray(result)) return result as BooleanMarket[];
+    // Sometimes result is wrapped in an object
+    if (result && typeof result === 'object' && 'markets' in (result as any)) {
+        return (result as any).markets as BooleanMarket[];
+    }
+    return [];
+}
+
+/**
+ * Get a specific boolean market by public key
+ */
+export async function getMarket(publicKey: string): Promise<BooleanMarket | null> {
+    const result = await callTool('get_market', { publicKey });
+    return (result as BooleanMarket) || null;
+}
+
+/**
+ * Get a bet quote for a boolean market
+ */
+export async function getQuote(market: string, side: string, amount: number): Promise<QuoteResult | null> {
+    const result = await callTool('get_quote', { market, side, amount });
+    return (result as QuoteResult) || null;
+}
+
+/**
+ * List all race markets, optionally filtered by status
+ */
+export async function listRaceMarkets(status?: string): Promise<RaceMarket[]> {
+    const args: Record<string, unknown> = {};
+    if (status) args.status = status;
+    const result = await callTool('list_race_markets', args);
+    if (Array.isArray(result)) return result as RaceMarket[];
+    if (result && typeof result === 'object' && 'markets' in (result as any)) {
+        return (result as any).markets as RaceMarket[];
+    }
+    return [];
+}
+
+/**
+ * Get a specific race market by public key
+ */
+export async function getRaceMarket(publicKey: string): Promise<RaceMarket | null> {
+    const result = await callTool('get_race_market', { publicKey });
+    return (result as RaceMarket) || null;
+}
+
+/**
+ * Get a quote for a race market outcome
+ */
+export async function getRaceQuote(market: string, outcomeIndex: number, amount: number): Promise<unknown> {
+    return callTool('get_race_quote', { market, outcomeIndex, amount });
+}
+
+/**
+ * Get positions for a wallet
+ */
+export async function getPositions(wallet: string): Promise<PositionsSummary | null> {
+    const result = await callTool('get_positions', { wallet });
+    return (result as PositionsSummary) || null;
+}
+
+/**
+ * Disconnect the MCP client
+ */
+export async function disconnect(): Promise<void> {
+    if (client) {
+        await client.close();
+        client = null;
+        transport = null;
+        console.log('[MCP] Disconnected');
+    }
+}

--- a/discord-bot/src/mcp/client.ts
+++ b/discord-bot/src/mcp/client.ts
@@ -38,6 +38,14 @@ async function getClient(): Promise<Client> {
 
         client = new Client({ name: 'baozi-discord-bot', version: '1.0.0' }, { capabilities: {} });
         await client.connect(transport);
+
+        // Auto-reconnect if MCP server crashes
+        transport.onclose = () => {
+            console.warn('[MCP] Connection lost — will reconnect on next request');
+            client = null;
+            transport = null;
+        };
+
         console.log('[MCP] Connected to @baozi.bet/mcp-server');
         return client;
     } catch (err) {
@@ -113,20 +121,20 @@ export interface RaceMarket {
 
 export interface Position {
     marketId: string;
-    market: string;
-    question: string;
+    publicKey: string;
+    marketQuestion: string;
     side: string;
-    amountSol: number;
+    totalAmountSol: number;
     status: string;
     winningOutcome: string | null;
-    claimable: boolean;
+    claimed: boolean;
 }
 
 export interface PositionsSummary {
     wallet: string;
     totalPositions: number;
     activePositions: number;
-    totalInvested: number;
+    totalBetSol: number;
     positions: Position[];
 }
 
@@ -162,7 +170,9 @@ export async function listMarkets(status?: string, layer?: string): Promise<Bool
  */
 export async function getMarket(publicKey: string): Promise<BooleanMarket | null> {
     const result = await callTool('get_market', { publicKey });
-    return (result as BooleanMarket) || null;
+    // MCP wraps in { success, network, market: {...} }
+    const data = result as any;
+    return (data?.market as BooleanMarket) || null;
 }
 
 /**
@@ -170,7 +180,9 @@ export async function getMarket(publicKey: string): Promise<BooleanMarket | null
  */
 export async function getQuote(market: string, side: string, amount: number): Promise<QuoteResult | null> {
     const result = await callTool('get_quote', { market, side, amount });
-    return (result as QuoteResult) || null;
+    // MCP wraps in { success, network, quote: {...} }
+    const data = result as any;
+    return (data?.quote as QuoteResult) || null;
 }
 
 /**
@@ -192,7 +204,9 @@ export async function listRaceMarkets(status?: string): Promise<RaceMarket[]> {
  */
 export async function getRaceMarket(publicKey: string): Promise<RaceMarket | null> {
     const result = await callTool('get_race_market', { publicKey });
-    return (result as RaceMarket) || null;
+    // MCP wraps in { success, network, market: {...} }
+    const data = result as any;
+    return (data?.market as RaceMarket) || null;
 }
 
 /**
@@ -207,7 +221,9 @@ export async function getRaceQuote(market: string, outcomeIndex: number, amount:
  */
 export async function getPositions(wallet: string): Promise<PositionsSummary | null> {
     const result = await callTool('get_positions', { wallet });
-    return (result as PositionsSummary) || null;
+    // MCP wraps in { success, network, portfolio: {...} }
+    const data = result as any;
+    return (data?.portfolio as PositionsSummary) || null;
 }
 
 /**

--- a/discord-bot/src/register-commands.ts
+++ b/discord-bot/src/register-commands.ts
@@ -1,0 +1,56 @@
+/**
+ * Register slash commands with Discord REST API
+ * Run with: npm run register
+ */
+import { REST, Routes } from 'discord.js';
+import * as dotenv from 'dotenv';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Load .env
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+dotenv.config({ path: path.join(__dirname, '..', '.env') });
+
+// Import all command data
+import { data as marketsCmd } from './commands/markets.js';
+import { data as oddsCmd } from './commands/odds.js';
+import { data as portfolioCmd } from './commands/portfolio.js';
+import { data as hotCmd } from './commands/hot.js';
+import { data as closingCmd } from './commands/closing.js';
+import { data as raceCmd } from './commands/race.js';
+import { data as setupCmd } from './commands/setup.js';
+
+const commands = [
+    marketsCmd.toJSON(),
+    oddsCmd.toJSON(),
+    portfolioCmd.toJSON(),
+    hotCmd.toJSON(),
+    closingCmd.toJSON(),
+    raceCmd.toJSON(),
+    setupCmd.toJSON(),
+];
+
+const TOKEN = process.env.DISCORD_TOKEN;
+const CLIENT_ID = process.env.DISCORD_CLIENT_ID;
+
+if (!TOKEN || !CLIENT_ID) {
+    console.error('Missing DISCORD_TOKEN or DISCORD_CLIENT_ID in .env');
+    process.exit(1);
+}
+
+const rest = new REST({ version: '10' }).setToken(TOKEN);
+
+async function register() {
+    try {
+        console.log(`Registering ${commands.length} slash commands...`);
+        await rest.put(Routes.applicationCommands(CLIENT_ID!), { body: commands });
+        console.log('✅ Slash commands registered globally!');
+        console.log('Commands:');
+        commands.forEach((cmd) => console.log(`  /${cmd.name} — ${cmd.description}`));
+    } catch (err) {
+        console.error('Failed to register commands:', err);
+        process.exit(1);
+    }
+}
+
+register();

--- a/discord-bot/src/roundup/scheduler.ts
+++ b/discord-bot/src/roundup/scheduler.ts
@@ -89,13 +89,9 @@ async function buildRoundupEmbeds(): Promise<EmbedBuilder[]> {
         );
     }
 
-    // ── Recently created (boolean markets from today) ──
+    // ── Closing soon (within 24h) ──
     const now = Date.now();
     const oneDayAgo = now - 24 * 60 * 60 * 1000;
-    // Since we don't have createdAt in the market data, use markets that are
-    // active with very small pools (newly created likely have small pools)
-    // Actually, we can check closing time — new markets tend to have future closing times
-    // Let's show markets closing soonest that still have activity
     const closingSoon = [...boolMarkets]
         .filter((m) => {
             const closeTime = new Date(m.closingTime).getTime();

--- a/discord-bot/src/roundup/scheduler.ts
+++ b/discord-bot/src/roundup/scheduler.ts
@@ -1,0 +1,231 @@
+/**
+ * Daily Roundup Scheduler
+ * Cron-based auto-posting of market summaries to configured channels.
+ */
+import { Client, EmbedBuilder, TextChannel } from 'discord.js';
+import cron from 'node-cron';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { listMarkets, listRaceMarkets } from '../mcp/client.js';
+import {
+    progressBar,
+    formatSol,
+    formatDate,
+    formatTime,
+    truncate,
+    marketUrl,
+    baoziFooter,
+    EMBED_COLORS,
+} from '../embeds/helpers.js';
+
+// ─── Guild Config Persistence ────────────────────────────────────────────────
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DATA_DIR = path.join(__dirname, '..', '..', 'data');
+const CONFIG_FILE = path.join(DATA_DIR, 'guild-config.json');
+
+export interface GuildRoundupConfig {
+    channelId: string;
+    hour: number;
+    minute: number;
+    enabled: boolean;
+}
+
+export type GuildConfigMap = Record<string, GuildRoundupConfig>;
+
+export function loadGuildConfig(): GuildConfigMap {
+    try {
+        if (fs.existsSync(CONFIG_FILE)) {
+            const raw = fs.readFileSync(CONFIG_FILE, 'utf-8');
+            return JSON.parse(raw) as GuildConfigMap;
+        }
+    } catch (err) {
+        console.error('[Roundup] Error reading config:', err);
+    }
+    return {};
+}
+
+export function saveGuildConfig(config: GuildConfigMap): void {
+    try {
+        if (!fs.existsSync(DATA_DIR)) {
+            fs.mkdirSync(DATA_DIR, { recursive: true });
+        }
+        fs.writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2));
+    } catch (err) {
+        console.error('[Roundup] Error saving config:', err);
+    }
+}
+
+// ─── Roundup Builder ─────────────────────────────────────────────────────────
+
+async function buildRoundupEmbeds(): Promise<EmbedBuilder[]> {
+    const embeds: EmbedBuilder[] = [];
+
+    // Fetch all markets
+    const [boolMarkets, raceMarkets] = await Promise.all([
+        listMarkets('Active'),
+        listRaceMarkets('Active'),
+    ]);
+
+    // ── Top 5 by pool size ──
+    const topByPool = [...boolMarkets]
+        .sort((a, b) => b.totalPoolSol - a.totalPoolSol)
+        .slice(0, 5);
+
+    if (topByPool.length > 0) {
+        const lines = topByPool.map((m, i) => {
+            const bar = progressBar(m.yesPercent);
+            return `**${i + 1}.** ${truncate(m.question, 55)}\nYes ${bar} ${m.yesPercent.toFixed(1)}% | Pool: ${formatSol(m.totalPoolSol)}\n[View](${marketUrl(m.publicKey)})`;
+        });
+
+        embeds.push(
+            new EmbedBuilder()
+                .setColor(EMBED_COLORS.PRIMARY)
+                .setTitle('📊 Daily Roundup — Top Markets by Pool')
+                .setDescription(lines.join('\n\n'))
+                .setFooter(baoziFooter())
+                .setTimestamp()
+        );
+    }
+
+    // ── Recently created (boolean markets from today) ──
+    const now = Date.now();
+    const oneDayAgo = now - 24 * 60 * 60 * 1000;
+    // Since we don't have createdAt in the market data, use markets that are
+    // active with very small pools (newly created likely have small pools)
+    // Actually, we can check closing time — new markets tend to have future closing times
+    // Let's show markets closing soonest that still have activity
+    const closingSoon = [...boolMarkets]
+        .filter((m) => {
+            const closeTime = new Date(m.closingTime).getTime();
+            return closeTime > now && closeTime <= now + 24 * 60 * 60 * 1000;
+        })
+        .sort((a, b) => new Date(a.closingTime).getTime() - new Date(b.closingTime).getTime())
+        .slice(0, 5);
+
+    if (closingSoon.length > 0) {
+        const lines = closingSoon.map((m) => {
+            return `⏰ **${truncate(m.question, 55)}**\nCloses: ${formatDate(m.closingTime)} | Pool: ${formatSol(m.totalPoolSol)}\n[View](${marketUrl(m.publicKey)})`;
+        });
+
+        embeds.push(
+            new EmbedBuilder()
+                .setColor(EMBED_COLORS.WARNING)
+                .setTitle('⏰ Closing Soon — Last Chance to Bet!')
+                .setDescription(lines.join('\n\n'))
+                .setTimestamp()
+        );
+    }
+
+    // ── Resolved markets ──
+    const allResolved = await listMarkets('Resolved');
+    const recentlyResolved = allResolved
+        .filter((m) => {
+            const resTime = new Date(m.resolutionTime).getTime();
+            return resTime > oneDayAgo;
+        })
+        .slice(0, 5);
+
+    if (recentlyResolved.length > 0) {
+        const lines = recentlyResolved.map((m) => {
+            return `✅ **${truncate(m.question, 55)}**\nResult: **${m.winningOutcome || 'N/A'}** | Pool: ${formatSol(m.totalPoolSol)}`;
+        });
+
+        embeds.push(
+            new EmbedBuilder()
+                .setColor(EMBED_COLORS.SUCCESS)
+                .setTitle('✅ Recently Resolved')
+                .setDescription(lines.join('\n\n'))
+                .setTimestamp()
+        );
+    }
+
+    // ── Race markets summary ──
+    if (raceMarkets.length > 0) {
+        const topRace = [...raceMarkets]
+            .sort((a, b) => b.totalPoolSol - a.totalPoolSol)
+            .slice(0, 3);
+
+        const lines = topRace.map((m) => {
+            const leader = [...m.outcomes].sort((a, b) => b.percent - a.percent)[0];
+            return `🏇 **${truncate(m.question, 55)}**\n🥇 ${leader?.label || '?'} (${leader?.percent.toFixed(1) || '?'}%) | Pool: ${formatSol(m.totalPoolSol)} | ${m.outcomes.length} outcomes\n[View](${marketUrl(m.publicKey)})`;
+        });
+
+        embeds.push(
+            new EmbedBuilder()
+                .setColor(EMBED_COLORS.RACE)
+                .setTitle('🏇 Race Markets')
+                .setDescription(lines.join('\n\n'))
+                .setTimestamp()
+        );
+    }
+
+    if (embeds.length === 0) {
+        embeds.push(
+            new EmbedBuilder()
+                .setColor(EMBED_COLORS.INFO)
+                .setTitle('📊 Daily Roundup')
+                .setDescription('No active markets to report today. Check back tomorrow!')
+                .setTimestamp()
+        );
+    }
+
+    return embeds;
+}
+
+// ─── Scheduler ───────────────────────────────────────────────────────────────
+
+const scheduledJobs: Map<string, cron.ScheduledTask> = new Map();
+
+/**
+ * Start or restart the roundup scheduler for all guilds
+ */
+export function startScheduler(discordClient: Client): void {
+    // Clear existing jobs
+    for (const [id, job] of scheduledJobs) {
+        job.stop();
+    }
+    scheduledJobs.clear();
+
+    const config = loadGuildConfig();
+
+    for (const [guildId, guildConf] of Object.entries(config)) {
+        if (!guildConf.enabled) continue;
+
+        const cronExpr = `${guildConf.minute} ${guildConf.hour} * * *`;
+        console.log(`[Roundup] Scheduling for guild ${guildId}: ${cronExpr} UTC -> #${guildConf.channelId}`);
+
+        const job = cron.schedule(
+            cronExpr,
+            async () => {
+                try {
+                    console.log(`[Roundup] Running roundup for guild ${guildId}`);
+                    const channel = await discordClient.channels.fetch(guildConf.channelId);
+                    if (!channel || !(channel instanceof TextChannel)) {
+                        console.error(`[Roundup] Channel ${guildConf.channelId} not found or not text`);
+                        return;
+                    }
+
+                    const embeds = await buildRoundupEmbeds();
+                    await channel.send({ embeds });
+                    console.log(`[Roundup] Posted roundup in #${channel.name} (${guildId})`);
+                } catch (err) {
+                    console.error(`[Roundup] Error posting to guild ${guildId}:`, err);
+                }
+            },
+            { timezone: 'UTC' }
+        );
+
+        scheduledJobs.set(guildId, job);
+    }
+
+    console.log(`[Roundup] ${scheduledJobs.size} guild(s) scheduled`);
+}
+
+/**
+ * Reload scheduler (called after /setup saves new config)
+ */
+export function reloadScheduler(discordClient: Client): void {
+    startScheduler(discordClient);
+}

--- a/discord-bot/tsconfig.json
+++ b/discord-bot/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "ESNext",
+        "moduleResolution": "bundler",
+        "outDir": "dist",
+        "rootDir": "src",
+        "strict": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true,
+        "resolveJsonModule": true,
+        "declaration": true,
+        "declarationMap": true,
+        "sourceMap": true
+    },
+    "include": [
+        "src/**/*"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
+}


### PR DESCRIPTION
## 🥟 Discord Market Bot — Bounty #10

### What This Does
Discord bot with **7 slash commands** and **rich embeds** that brings Baozi prediction market data into Discord servers. Browse markets, see odds, track portfolios — all without leaving Discord.

**Read-only.** No wallet management, no transaction signing.

### Commands

| Command | Description |
|---------|-------------|
| `/markets [category]` | Browse active markets (optional keyword filter) |
| `/odds <marketId>` | Detailed odds embed with progress bars + payouts |
| `/portfolio <wallet>` | View betting positions for any Solana wallet |
| `/hot` | Highest volume markets by pool size |
| `/closing` | Markets closing within 24h |
| `/race <marketId>` | Race (multi-outcome) market with all outcome odds |
| `/setup #channel HH:MM` | Configure daily automated market roundup |

### Data Source
All data fetched live from **Solana mainnet** via `@baozi.bet/mcp-server` MCP tools. Zero hardcoded data.

### Proof of Working
- ✅ TypeScript builds with zero errors (21 files, 3764 lines)
- ✅ MCP connectivity test passed — fetched 5 boolean + 19 race markets from mainnet
- ✅ Bot authorized and responding in Discord with real market data
- ✅ All 7 slash commands visible and functional

### Architecture
```
discord-bot/
├── src/
│   ├── index.ts              # Main entry
│   ├── mcp/client.ts         # MCP client → @baozi.bet/mcp-server
│   ├── commands/             # 7 slash commands
│   ├── embeds/               # Rich embed builders
│   └── roundup/scheduler.ts  # Cron-based daily roundup
├── .env.example
└── README.md                 # Full setup guide
```

### Solana Wallet
3CZ9kv5yYyMb8gr6u8ZRCt2wgehZBZdJo8HnMr9XNCzR




https://github.com/user-attachments/assets/d2f868c0-c854-4b9a-9d8f-f5690aae0b6a




Closes #10