### PR TITLE
feat: Agent Arena — Live AI Betting Competition Dashboard

### DIFF
--- a/submissions/agent-arena/README.md
+++ b/submissions/agent-arena/README.md
@@ -13,23 +13,23 @@ npm install -g @baozi.bet/mcp-server
 
 ```bash
 # Live dashboard (auto-refreshes every 30s)
-python agent.py
+python3 agent.py
 
 # Custom wallets
-python agent.py --wallets WALLET1,WALLET2,WALLET3
+python3 agent.py --wallets WALLET1,WALLET2,WALLET3
 
 # Faster refresh (every 15 seconds)
-python agent.py --refresh 15
+python3 agent.py --refresh 15
 
 # Run once, print, exit (good for screenshots)
-python agent.py --once
+python3 agent.py --once
 
 # Demo mode — fully offline with mock data
-python agent.py --demo
+python3 agent.py --demo
 
 # Combine flags
-python agent.py --demo --once
-python agent.py --wallets W1,W2 --refresh 10
+python3 agent.py --demo --once
+python3 agent.py --wallets W1,W2 --refresh 10
 ```
 
 ## Dashboard Preview
@@ -61,7 +61,7 @@ python agent.py --wallets W1,W2 --refresh 10
 Pass wallet addresses as a comma-separated list:
 
 ```bash
-python agent.py --wallets GZgrz2vtbc1o1kjipM1X3EFAf2VM54j9MVxGWSGbGmai,ANOTHER_WALLET
+python3 agent.py --wallets GZgrz2vtbc1o1kjipM1X3EFAf2VM54j9MVxGWSGbGmai,ANOTHER_WALLET
 ```
 
 Or edit `DEFAULT_WALLETS` in `agent.py` to change the defaults.
@@ -93,6 +93,43 @@ unrealized_pnl = payout_if_win - amount
 ```
 
 The 3% fee is the Baozi platform fee. Resolved positions use actual payout data.
+
+## Live Demo Output
+
+Run `python3 agent.py --demo --once` to see the full dashboard offline:
+
+```
+╭──────────────────────────────────────────────────────────────────────────────╮
+│   AGENT ARENA — Live Competition (DEMO MODE)                                 │
+│   Updated: 2026-02-20 03:56:05 UTC  |  Refresh in: 0s                        │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭──────────────────────────────── LEADERBOARD ─────────────────────────────────╮
+│  Rk    Agent           Wallet     #    Acc    W    P&L SOL    Vol SOL         │
+│  #1    AlphaHunter     A1ph...    2    86%    3W   +12.50     45.2            │
+│  #2    CryptoSage      Cr3p...    1    71%    2W   +8.20      38.1            │
+│  #3    BearBot         Be4r...    2    33%    -    -2.10      22.8            │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─────────────────────────────── ACTIVE MARKETS ───────────────────────────────╮
+│ ╭─── "Will BTC hit $110k by March 1?" ────────────────────────────────────╮  │
+│ │   Pool: 45.2 SOL  |  YES: 62%  |  NO: 38%  |  Closes: 2h 15m           │  │
+│ │                                                                          │  │
+│ │   AlphaHunter    -> 5.0 SOL YES  (unrealized: +2.83 SOL)                │  │
+│ │   CryptoSage     -> 3.5 SOL YES  (unrealized: +1.98 SOL)                │  │
+│ │   BearBot        -> 3.0 SOL NO   (unrealized: +4.65 SOL)                │  │
+│ ╰──────────────────────────────────────────────────────────────────────────╯  │
+│ ╭─── "Will ETH break $5,000 before Feb 28?" ──────────────────────────────╮  │
+│ │   Pool: 32.8 SOL  |  YES: 44%  |  NO: 56%  |  Closes: 18h 30m          │  │
+│ │                                                                          │  │
+│ │   AlphaHunter    -> 3.0 SOL NO   (unrealized: +2.16 SOL)                │  │
+│ │   BearBot        -> 2.5 SOL YES  (unrealized: +3.06 SOL)                │  │
+│ ╰──────────────────────────────────────────────────────────────────────────╯  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭──────────────────────── AlphaHunter — Open Positions ────────────────────────╮
+│  Market                                   Side    Amount    Unreal P&L        │
+│  Will BTC hit $110k by March 1?           YES     5.00 SOL  +2.83 SOL        │
+│  Will ETH break $5,000 before Feb 28?     NO      3.00 SOL  +2.16 SOL        │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
 
 ## Requirements
 

--- a/submissions/agent-arena/README.md
+++ b/submissions/agent-arena/README.md
@@ -1,0 +1,101 @@
+# Agent Arena — Live AI Betting Competition Dashboard
+
+Real-time terminal dashboard that monitors multiple AI agent wallets competing on [Baozi](https://baozi.bet) prediction markets. Tracks live positions, P&L, accuracy, and ranks agents by performance.
+
+## Install
+
+```bash
+pip install -r requirements.txt
+npm install -g @baozi.bet/mcp-server
+```
+
+## Usage
+
+```bash
+# Live dashboard (auto-refreshes every 30s)
+python agent.py
+
+# Custom wallets
+python agent.py --wallets WALLET1,WALLET2,WALLET3
+
+# Faster refresh (every 15 seconds)
+python agent.py --refresh 15
+
+# Run once, print, exit (good for screenshots)
+python agent.py --once
+
+# Demo mode — fully offline with mock data
+python agent.py --demo
+
+# Combine flags
+python agent.py --demo --once
+python agent.py --wallets W1,W2 --refresh 10
+```
+
+## Dashboard Preview
+
+```
+╔══════════════════════════════════════════════════════════════════╗
+║  AGENT ARENA — Live Competition                                  ║
+║  Updated: 2026-02-19 19:42:00 UTC  |  Refresh in: 28s           ║
+╠══════════════════════════════════════════════════════════════════╣
+║  LEADERBOARD                                                      ║
+║  Rank  Agent          Wallet     Open Accuracy Streak P&L    Vol  ║
+║  #1    AlphaHunter    A1ph...    2    86%      3W     +12.50 45.2 ║
+║  #2    CryptoSage     Cr3p...    1    71%      2W     +8.20  38.1 ║
+║  #3    BearBot        Be4r...    2    33%      -      -2.10  22.8 ║
+╠══════════════════════════════════════════════════════════════════╣
+║  ACTIVE MARKETS                                                   ║
+║  ┌────────────────────────────────────────────────────────────┐   ║
+║  │ "Will BTC hit $110k by March 1?"                           │   ║
+║  │ Pool: 45.2 SOL  |  YES: 62%  |  NO: 38%  |  Closes: 2h   │   ║
+║  │ AlphaHunter    -> 5.0 SOL YES  (unrealized: +2.73 SOL)    │   ║
+║  │ CryptoSage     -> 3.5 SOL YES  (unrealized: +1.91 SOL)    │   ║
+║  │ BearBot        -> 3.0 SOL NO   (unrealized: +4.72 SOL)    │   ║
+║  └────────────────────────────────────────────────────────────┘   ║
+╚══════════════════════════════════════════════════════════════════╝
+```
+
+## Adding Custom Wallets
+
+Pass wallet addresses as a comma-separated list:
+
+```bash
+python agent.py --wallets GZgrz2vtbc1o1kjipM1X3EFAf2VM54j9MVxGWSGbGmai,ANOTHER_WALLET
+```
+
+Or edit `DEFAULT_WALLETS` in `agent.py` to change the defaults.
+
+To discover active wallets, the tool auto-fetches creator addresses from Baozi Lab markets via the MCP server.
+
+## Architecture
+
+```
+agent-arena/
+├── agent.py          # Main dashboard + refresh loop (rich terminal UI)
+├── mcp_client.py     # MCP JSON-RPC wrapper (subprocess communication)
+├── arena.py          # Arena logic (fetch positions, calc P&L, rank agents)
+├── requirements.txt  # Python dependencies
+└── README.md
+```
+
+- **mcp_client.py** — Spawns `npx @baozi.bet/mcp-server` as a subprocess, sends JSON-RPC over stdin/stdout. Exposes `list_markets()`, `get_market()`, `get_positions()`, `get_quote()`, and `discover_wallets()`.
+- **arena.py** — Data classes (`Position`, `MarketInfo`, `AgentStats`), P&L calculation (pari-mutuel with 3% fee), parallel agent data fetching, and demo mode mock data.
+- **agent.py** — CLI argument parsing, rich terminal rendering (leaderboard table, market panels, position details), and the auto-refresh loop.
+
+## How P&L Works
+
+Uses pari-mutuel payout estimation:
+
+```
+payout_if_win = (total_pool / side_pool) * amount * 0.97
+unrealized_pnl = payout_if_win - amount
+```
+
+The 3% fee is the Baozi platform fee. Resolved positions use actual payout data.
+
+## Requirements
+
+- Python 3.10+
+- Node.js / npm (for the Baozi MCP server)
+- Terminal with color support (any modern terminal)

--- a/submissions/agent-arena/agent.py
+++ b/submissions/agent-arena/agent.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+"""
+agent.py — Agent Arena: Live AI Betting Competition Dashboard.
+
+Monitors multiple AI agent wallets competing on Baozi prediction markets,
+showing live positions, P&L, and rankings in a rich terminal UI.
+
+Usage:
+    python agent.py                        # live dashboard (default)
+    python agent.py --wallets W1,W2,W3    # custom wallet list
+    python agent.py --refresh 15          # refresh interval in seconds
+    python agent.py --once                # run once, print, exit
+    python agent.py --demo                # demo mode with mock data
+"""
+
+from __future__ import annotations
+
+import argparse
+import signal
+import sys
+import time
+from datetime import datetime, timezone
+
+from rich.console import Console, Group
+from rich.live import Live
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+
+import arena
+
+# Default wallets to track — includes our wallet + known Baozi creators.
+# If fewer than 3 are reachable, the arena will auto-discover more from
+# active Lab market creators via mcp_client.discover_wallets().
+DEFAULT_WALLETS = [
+    "GZgrz2vtbc1o1kjipM1X3EFAf2VM54j9MVxGWSGbGmai",  # CruzBot
+    "DfMxre4cKmvogbLrPigxmibVTTQDuzjdXojWzjCXXhzj",  # known Baozi Labs creator
+    "HN7cABqLq46Es1jh92dQQisAq662SmxELLLsHHe4YWrH",  # known Baozi Labs creator
+]
+
+REFRESH_DEFAULT = 30
+
+
+# ── rendering ──────────────────────────────────────────────────────
+
+
+def _pnl_color(val: float) -> str:
+    if val > 0:
+        return "green"
+    if val < 0:
+        return "red"
+    return "white"
+
+
+def _fmt_pnl(val: float) -> str:
+    sign = "+" if val > 0 else ""
+    return f"{sign}{val:.2f}"
+
+
+def _fmt_hours(h: float) -> str:
+    if h >= 9999:
+        return "N/A"
+    if h < 1:
+        mins = int(h * 60)
+        return f"{mins}m"
+    if h < 24:
+        return f"{h:.0f}h {int((h % 1) * 60)}m"
+    days = int(h / 24)
+    return f"{days}d {int(h % 24)}h"
+
+
+def _truncate(wallet: str) -> str:
+    if len(wallet) > 12:
+        return wallet[:4] + "..."
+    return wallet
+
+
+def build_header(refresh_interval: int, countdown: int, demo: bool) -> Panel:
+    """Build the header panel."""
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+    mode = " [bold yellow](DEMO MODE)[/]" if demo else ""
+
+    header_text = Text.from_markup(
+        f"  [bold cyan]AGENT ARENA[/] — Live Competition{mode}\n"
+        f"  Updated: {now}  |  Refresh in: {countdown}s"
+    )
+    return Panel(
+        header_text,
+        border_style="bright_cyan",
+        padding=(0, 1),
+    )
+
+
+def build_leaderboard(agents: list[arena.AgentStats]) -> Panel:
+    """Build the leaderboard table."""
+    table = Table(
+        show_header=True,
+        header_style="bold white",
+        border_style="cyan",
+        expand=True,
+        pad_edge=True,
+    )
+    table.add_column("Rk", style="bold", width=3, justify="center")
+    table.add_column("Agent", style="bold white", width=14, no_wrap=True)
+    table.add_column("Wallet", style="dim", width=9)
+    table.add_column("#", justify="center", width=2)
+    table.add_column("Acc", justify="center", width=5)
+    table.add_column("W", justify="center", width=3)
+    table.add_column("P&L SOL", justify="right", width=9)
+    table.add_column("Vol SOL", justify="right", width=8)
+
+    for i, agent in enumerate(agents, 1):
+        rank_style = "bold yellow" if i == 1 else ("bold white" if i == 2 else "white")
+        medal = {1: "#1", 2: "#2", 3: "#3"}.get(i, f"#{i}")
+        pnl = _fmt_pnl(agent.total_pnl)
+        pnl_style = _pnl_color(agent.total_pnl)
+        acc = f"{agent.accuracy:.0f}%" if agent.accuracy > 0 else "-"
+        streak = f"{agent.win_streak}W" if agent.win_streak > 0 else "-"
+        open_count = str(len(agent.open_positions))
+
+        table.add_row(
+            Text(medal, style=rank_style),
+            Text(agent.name, style="bold"),
+            Text(_truncate(agent.wallet), style="dim"),
+            open_count,
+            acc,
+            streak,
+            Text(pnl, style=pnl_style),
+            f"{agent.total_wagered:.1f}",
+        )
+
+    return Panel(
+        table,
+        title="[bold white]LEADERBOARD[/]",
+        border_style="cyan",
+        padding=(0, 0),
+    )
+
+
+def build_market_panel(market: arena.MarketInfo) -> Panel:
+    """Build a panel for a single active market."""
+    lines: list[str] = []
+
+    pool_str = f"Pool: {market.total_pool:.1f} SOL"
+    odds_str = f"YES: {market.yes_pct:.0f}%  |  NO: {market.no_pct:.0f}%"
+    time_str = f"Closes: {_fmt_hours(market.hours_left)}"
+    lines.append(f"  {pool_str}  |  {odds_str}  |  {time_str}")
+    lines.append("")
+
+    if market.positions:
+        for agent_name, pos in market.positions:
+            pnl_str = _fmt_pnl(pos.unrealized_pnl)
+            pnl_clr = _pnl_color(pos.unrealized_pnl)
+            side_clr = "green" if pos.side.lower() == "yes" else "red"
+            lines.append(
+                f"  [{side_clr}]{agent_name:14s}[/] -> "
+                f"{pos.amount:.1f} SOL [{side_clr}]{pos.side.upper():3s}[/]  "
+                f"(unrealized: [{pnl_clr}]{pnl_str} SOL[/])"
+            )
+    else:
+        lines.append("  [dim]No tracked agents in this market[/]")
+
+    content = Text.from_markup("\n".join(lines))
+    question = market.question
+    if len(question) > 70:
+        question = question[:67] + "..."
+
+    return Panel(
+        content,
+        title=f'[bold white]"{question}"[/]',
+        border_style="bright_blue",
+        padding=(0, 1),
+    )
+
+
+def build_dashboard(
+    agents: list[arena.AgentStats],
+    markets: list[arena.MarketInfo],
+    refresh_interval: int,
+    countdown: int,
+    demo: bool,
+) -> Group:
+    """Compose the full dashboard as a Group of renderables."""
+    parts: list[object] = []
+
+    parts.append(build_header(refresh_interval, countdown, demo))
+    parts.append(build_leaderboard(agents))
+
+    # Market panels
+    market_panels: list[Panel] = []
+    for m in markets[:6]:
+        market_panels.append(build_market_panel(m))
+
+    if not market_panels:
+        market_panels.append(Panel(
+            Text.from_markup("  [dim]No active markets with tracked positions[/]"),
+            title="[bold white]ACTIVE MARKETS[/]",
+            border_style="bright_blue",
+        ))
+
+    markets_container = Panel(
+        Group(*market_panels),
+        title="[bold white]ACTIVE MARKETS[/]",
+        border_style="cyan",
+        padding=(0, 0),
+    )
+    parts.append(markets_container)
+
+    # Agent detail: open positions for top agent
+    if agents and agents[0].open_positions:
+        top = agents[0]
+        pos_table = Table(
+            show_header=True,
+            header_style="bold white",
+            border_style="cyan",
+            expand=True,
+        )
+        pos_table.add_column("Market", ratio=2, no_wrap=True)
+        pos_table.add_column("Side", justify="center", width=5)
+        pos_table.add_column("Amount", justify="right", width=10)
+        pos_table.add_column("Unreal P&L", justify="right", width=12)
+
+        for pos in top.open_positions:
+            q = pos.market_question
+            if len(q) > 45:
+                q = q[:42] + "..."
+            side_style = "green" if pos.side.lower() == "yes" else "red"
+            pnl_style = _pnl_color(pos.unrealized_pnl)
+            pos_table.add_row(
+                q,
+                Text(pos.side.upper(), style=side_style),
+                f"{pos.amount:.2f} SOL",
+                Text(f"{_fmt_pnl(pos.unrealized_pnl)} SOL", style=pnl_style),
+            )
+        detail_panel = Panel(
+            pos_table,
+            title=f"[bold white]{top.name} — Open Positions[/]",
+            border_style="cyan",
+            padding=(0, 0),
+        )
+        parts.append(detail_panel)
+
+    return Group(*parts)
+
+
+# ── fetch data ─────────────────────────────────────────────────────
+
+
+def fetch_all_data(
+    wallets: list[str],
+    demo: bool = False,
+) -> tuple[list[arena.AgentStats], list[arena.MarketInfo]]:
+    """Fetch or generate all dashboard data."""
+    if demo:
+        return arena.demo_data()
+    return arena.fetch_all_agents(wallets)
+
+
+# ── main loop ──────────────────────────────────────────────────────
+
+
+def run_once(
+    wallets: list[str],
+    demo: bool,
+    console: Console,
+) -> None:
+    """Fetch data, render once, and exit."""
+    agents, markets = fetch_all_data(wallets, demo)
+    if not agents:
+        console.print("[yellow]No agent data found.[/]")
+        return
+    layout = build_dashboard(agents, markets, 0, 0, demo)
+    console.print(layout)
+
+
+def run_loop(
+    wallets: list[str],
+    refresh_interval: int,
+    demo: bool,
+    console: Console,
+) -> None:
+    """Continuous refresh loop with Rich Live display."""
+    # Graceful exit on Ctrl+C
+    stop = False
+
+    def _handler(sig: int, frame: object) -> None:
+        nonlocal stop
+        stop = True
+
+    signal.signal(signal.SIGINT, _handler)
+    signal.signal(signal.SIGTERM, _handler)
+
+    console.print(
+        f"[bold cyan]Agent Arena[/] starting — "
+        f"tracking {len(wallets)} wallet(s), "
+        f"refresh every {refresh_interval}s  "
+        f"[dim](Ctrl+C to quit)[/]\n"
+    )
+
+    with Live(console=console, refresh_per_second=1, screen=True) as live:
+        while not stop:
+            try:
+                agents, markets = fetch_all_data(wallets, demo)
+            except Exception as exc:
+                console.print(f"[red]Error fetching data: {exc}[/]")
+                agents, markets = [], []
+
+            # Countdown loop
+            for remaining in range(refresh_interval, 0, -1):
+                if stop:
+                    break
+                layout = build_dashboard(
+                    agents, markets, refresh_interval, remaining, demo
+                )
+                live.update(layout)
+                time.sleep(1)
+
+    console.print("\n[bold cyan]Agent Arena[/] stopped.")
+
+
+# ── CLI ────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Agent Arena — Live AI Betting Competition Dashboard",
+    )
+    parser.add_argument(
+        "--wallets",
+        type=str,
+        default=None,
+        help="Comma-separated list of wallet addresses to track",
+    )
+    parser.add_argument(
+        "--refresh",
+        type=int,
+        default=REFRESH_DEFAULT,
+        help=f"Refresh interval in seconds (default: {REFRESH_DEFAULT})",
+    )
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        help="Run once, print dashboard, and exit",
+    )
+    parser.add_argument(
+        "--demo",
+        action="store_true",
+        help="Demo mode with mock data (no API needed)",
+    )
+
+    args = parser.parse_args()
+
+    wallets = DEFAULT_WALLETS
+    if args.wallets:
+        wallets = [w.strip() for w in args.wallets.split(",") if w.strip()]
+
+    # Auto-discover more wallets from active Lab market creators if we have < 3
+    if not args.demo and len(wallets) < 3:
+        console_pre = Console()
+        console_pre.print("[dim]Discovering wallets from active markets...[/]")
+        discovered = arena.mcp_client.discover_wallets(limit=50)
+        for w in discovered:
+            if w not in wallets:
+                wallets.append(w)
+            if len(wallets) >= 5:
+                break
+
+    if not wallets and not args.demo:
+        print("Error: no wallets specified. Use --wallets or --demo.", file=sys.stderr)
+        sys.exit(1)
+
+    console = Console()
+
+    if args.once:
+        run_once(wallets, args.demo, console)
+    else:
+        run_loop(wallets, args.refresh, args.demo, console)
+
+
+if __name__ == "__main__":
+    main()

--- a/submissions/agent-arena/arena.py
+++ b/submissions/agent-arena/arena.py
@@ -1,0 +1,525 @@
+"""
+arena.py — Arena logic: fetch positions, calculate P&L, rank agents.
+
+Core data structures
+--------------------
+Position  — a single bet (open or resolved)
+AgentStats — aggregated stats for one wallet
+MarketInfo — pool state for one market
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import json
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+import mcp_client
+
+
+# ── data classes ────────────────────────────────────────────────────
+
+
+@dataclass
+class Position:
+    market_pda: str
+    market_question: str
+    side: str          # "Yes" or "No"
+    amount: float      # SOL wagered
+    unrealized_pnl: float = 0.0
+    actual_pnl: float | None = None   # set when resolved
+    outcome: str | None = None        # "won" / "lost" / None
+    is_resolved: bool = False
+
+
+@dataclass
+class MarketInfo:
+    pda: str
+    question: str
+    yes_pool: float       # SOL
+    no_pool: float        # SOL
+    total_pool: float     # SOL
+    yes_pct: float        # 0-100
+    no_pct: float         # 0-100
+    status: str           # "Active", "Resolved", etc.
+    closing_time: str     # ISO or epoch string
+    hours_left: float
+    positions: list[tuple[str, Position]] = field(default_factory=list)
+    # (agent_name, Position) pairs — filled during dashboard assembly
+
+
+@dataclass
+class AgentStats:
+    wallet: str
+    name: str
+    open_positions: list[Position] = field(default_factory=list)
+    resolved_positions: list[Position] = field(default_factory=list)
+    total_wagered: float = 0.0
+    total_pnl: float = 0.0
+    accuracy: float = 0.0     # 0-100
+    win_streak: int = 0
+
+
+# ── agent profile ──────────────────────────────────────────────────
+
+PROFILE_URL = "https://baozi.bet/api/agents/profile/{wallet}"
+
+
+def fetch_agent_name(wallet: str) -> str:
+    """Fetch agent display name from Baozi API; fall back to truncated address."""
+    try:
+        result = subprocess.run(
+            ["curl", "-s", "--max-time", "5", PROFILE_URL.format(wallet=wallet)],
+            capture_output=True, text=True, timeout=8,
+        )
+        data = json.loads(result.stdout)
+        name = data.get("name") or data.get("displayName") or data.get("username")
+        if name:
+            return str(name)
+    except Exception:
+        pass
+    return _truncate_wallet(wallet)
+
+
+def _truncate_wallet(wallet: str) -> str:
+    if len(wallet) > 8:
+        return wallet[:4] + "..." + wallet[-4:]
+    return wallet
+
+
+# ── market helpers ─────────────────────────────────────────────────
+
+
+def _hours_left(raw: Any) -> float:
+    if not raw:
+        return 9999.0
+    try:
+        if isinstance(raw, (int, float)):
+            ts = raw / 1000 if raw > 1e11 else raw
+        else:
+            s = str(raw).replace("Z", "+00:00")
+            ts = datetime.fromisoformat(s).timestamp()
+        return max(0.0, (ts - datetime.now(timezone.utc).timestamp()) / 3600)
+    except Exception:
+        return 9999.0
+
+
+def _pool_sol(m: dict[str, Any]) -> float:
+    v = m.get("totalPoolSol")
+    if v is not None:
+        return float(v)
+    lamps = m.get("totalPool") or m.get("pool") or 0
+    return float(lamps) / 1e9
+
+
+def _yes_pct(m: dict[str, Any]) -> float:
+    y = m.get("yesPercent")
+    if y is not None:
+        return float(y)
+    outcomes = m.get("outcomes", [])
+    for o in outcomes:
+        if str(o.get("label", "")).upper() == "YES":
+            p = o.get("probability") or o.get("odds", 0)
+            return (p * 100) if p <= 1 else float(p)
+    return 50.0
+
+
+def parse_market(m: dict[str, Any]) -> MarketInfo:
+    """Parse raw MCP market dict into a MarketInfo."""
+    total = _pool_sol(m)
+    y_pct = _yes_pct(m)
+    n_pct = 100.0 - y_pct
+    yes_pool = total * (y_pct / 100) if total > 0 else 0.0
+    no_pool = total * (n_pct / 100) if total > 0 else 0.0
+
+    closing = m.get("closingTime") or m.get("closeTime") or m.get("endTime") or ""
+    status = m.get("status", "Active")
+    if m.get("isBettingOpen"):
+        status = "Active"
+
+    return MarketInfo(
+        pda=m.get("publicKey", ""),
+        question=m.get("question", "Unknown market"),
+        yes_pool=yes_pool,
+        no_pool=no_pool,
+        total_pool=total,
+        yes_pct=y_pct,
+        no_pct=n_pct,
+        status=status,
+        closing_time=str(closing),
+        hours_left=_hours_left(closing),
+    )
+
+
+# ── P&L calculation ───────────────────────────────────────────────
+
+FEE_RATE = 0.03  # 3% platform fee
+
+
+def calc_unrealized_pnl(
+    side: str,
+    amount: float,
+    market: MarketInfo,
+) -> float:
+    """Pari-mutuel unrealized P&L estimate."""
+    if market.total_pool <= 0 or amount <= 0:
+        return 0.0
+
+    if side.lower() == "yes":
+        pool = market.yes_pool if market.yes_pool > 0 else 0.01
+    else:
+        pool = market.no_pool if market.no_pool > 0 else 0.01
+
+    payout_if_win = (market.total_pool / pool) * amount * (1 - FEE_RATE)
+    return payout_if_win - amount
+
+
+# ── fetch & compute agent stats ───────────────────────────────────
+
+
+def _parse_position(
+    raw: dict[str, Any],
+    market_cache: dict[str, MarketInfo],
+) -> Position:
+    """Parse a raw position dict into a Position with P&L."""
+    market_pda = raw.get("market") or raw.get("marketPda") or raw.get("publicKey", "")
+    side = raw.get("side") or raw.get("outcome") or "Yes"
+    amount_raw = raw.get("amount") or raw.get("stake") or raw.get("size") or 0
+    amount = float(amount_raw)
+    # Convert lamports to SOL if needed
+    if amount > 1000:
+        amount = amount / 1e9
+
+    question = raw.get("question") or raw.get("marketQuestion") or ""
+    is_resolved = raw.get("isResolved", False) or raw.get("settled", False)
+
+    pos = Position(
+        market_pda=market_pda,
+        market_question=question,
+        side=side,
+        amount=amount,
+        is_resolved=is_resolved,
+    )
+
+    if is_resolved:
+        payout = raw.get("payout") or raw.get("winnings") or 0
+        payout_f = float(payout)
+        if payout_f > 1000:
+            payout_f = payout_f / 1e9
+        pos.actual_pnl = payout_f - amount
+        pos.outcome = "won" if payout_f > amount else "lost"
+    else:
+        # Calculate unrealized P&L from market state
+        market = market_cache.get(market_pda)
+        if market:
+            pos.unrealized_pnl = calc_unrealized_pnl(side, amount, market)
+            if not pos.market_question:
+                pos.market_question = market.question
+
+    return pos
+
+
+def fetch_agent_stats(
+    wallet: str,
+    name: str | None = None,
+    market_cache: dict[str, MarketInfo] | None = None,
+) -> AgentStats:
+    """Fetch positions for a wallet and compute stats."""
+    if market_cache is None:
+        market_cache = {}
+
+    agent_name = name or fetch_agent_name(wallet)
+    raw_positions = mcp_client.get_positions(wallet)
+
+    stats = AgentStats(wallet=wallet, name=agent_name)
+
+    for raw in raw_positions:
+        pos = _parse_position(raw, market_cache)
+        if pos.is_resolved:
+            stats.resolved_positions.append(pos)
+        else:
+            stats.open_positions.append(pos)
+
+    # Aggregates
+    stats.total_wagered = sum(p.amount for p in stats.open_positions + stats.resolved_positions)
+    open_pnl = sum(p.unrealized_pnl for p in stats.open_positions)
+    resolved_pnl = sum(p.actual_pnl or 0 for p in stats.resolved_positions)
+    stats.total_pnl = open_pnl + resolved_pnl
+
+    # Accuracy
+    resolved_count = len(stats.resolved_positions)
+    if resolved_count > 0:
+        wins = sum(1 for p in stats.resolved_positions if p.outcome == "won")
+        stats.accuracy = (wins / resolved_count) * 100
+    else:
+        stats.accuracy = 0.0
+
+    # Win streak (most recent consecutive wins)
+    streak = 0
+    for p in reversed(stats.resolved_positions):
+        if p.outcome == "won":
+            streak += 1
+        else:
+            break
+    stats.win_streak = streak
+
+    return stats
+
+
+def fetch_all_agents(
+    wallets: list[str],
+    names: dict[str, str] | None = None,
+) -> tuple[list[AgentStats], list[MarketInfo]]:
+    """Fetch data for all wallets in parallel. Returns (agents, markets)."""
+    if names is None:
+        names = {}
+
+    # 1) Fetch markets and build cache
+    raw_markets = mcp_client.list_markets()
+    market_cache: dict[str, MarketInfo] = {}
+    markets: list[MarketInfo] = []
+    for m in raw_markets:
+        info = parse_market(m)
+        if info.pda:
+            market_cache[info.pda] = info
+        markets.append(info)
+
+    # 2) Fetch agent names in parallel if not provided
+    wallet_names: dict[str, str] = dict(names)
+    missing = [w for w in wallets if w not in wallet_names]
+    if missing:
+        with ThreadPoolExecutor(max_workers=5) as pool:
+            futures = {pool.submit(fetch_agent_name, w): w for w in missing}
+            for f in as_completed(futures):
+                w = futures[f]
+                try:
+                    wallet_names[w] = f.result()
+                except Exception:
+                    wallet_names[w] = _truncate_wallet(w)
+
+    # 3) Fetch positions in parallel
+    agents: list[AgentStats] = []
+    with ThreadPoolExecutor(max_workers=5) as pool:
+        futures = {
+            pool.submit(fetch_agent_stats, w, wallet_names.get(w), market_cache): w
+            for w in wallets
+        }
+        for f in as_completed(futures):
+            try:
+                agents.append(f.result())
+            except Exception as exc:
+                w = futures[f]
+                print(f"[arena] error fetching {w}: {exc}", file=sys.stderr)
+                agents.append(AgentStats(
+                    wallet=w,
+                    name=wallet_names.get(w, _truncate_wallet(w)),
+                ))
+
+    # 4) Rank by P&L descending
+    agents.sort(key=lambda a: a.total_pnl, reverse=True)
+
+    # 5) Attach agent positions to markets
+    for agent in agents:
+        for pos in agent.open_positions:
+            if pos.market_pda in market_cache:
+                market_cache[pos.market_pda].positions.append((agent.name, pos))
+
+    active_markets = [m for m in markets if m.status == "Active" and m.positions]
+
+    return agents, active_markets
+
+
+# ── demo mode mock data ───────────────────────────────────────────
+
+
+def demo_data() -> tuple[list[AgentStats], list[MarketInfo]]:
+    """Return realistic mock data — fully offline, no API calls."""
+
+    # Markets
+    m1 = MarketInfo(
+        pda="BTC110kMar2026xxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        question="Will BTC hit $110k by March 1?",
+        yes_pool=28.0,
+        no_pool=17.2,
+        total_pool=45.2,
+        yes_pct=62.0,
+        no_pct=38.0,
+        status="Active",
+        closing_time="2026-03-01T00:00:00Z",
+        hours_left=2.25,
+    )
+
+    m2 = MarketInfo(
+        pda="ETH5kFeb2026xxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        question="Will ETH break $5,000 before Feb 28?",
+        yes_pool=14.3,
+        no_pool=18.5,
+        total_pool=32.8,
+        yes_pct=43.6,
+        no_pct=56.4,
+        status="Active",
+        closing_time="2026-02-28T23:59:59Z",
+        hours_left=18.5,
+    )
+
+    # Agents
+    alpha = AgentStats(
+        wallet="A1phHunt3rxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        name="AlphaHunter",
+        open_positions=[
+            Position(
+                market_pda=m1.pda, market_question=m1.question,
+                side="Yes", amount=5.0,
+                unrealized_pnl=calc_unrealized_pnl("Yes", 5.0, m1),
+            ),
+            Position(
+                market_pda=m2.pda, market_question=m2.question,
+                side="No", amount=3.0,
+                unrealized_pnl=calc_unrealized_pnl("No", 3.0, m2),
+            ),
+        ],
+        resolved_positions=[
+            Position(
+                market_pda="resolved1", market_question="SOL above $200 by Jan?",
+                side="Yes", amount=4.0, actual_pnl=3.5, outcome="won", is_resolved=True,
+            ),
+            Position(
+                market_pda="resolved2", market_question="DOGE to $1 by Dec?",
+                side="No", amount=2.5, actual_pnl=1.8, outcome="won", is_resolved=True,
+            ),
+            Position(
+                market_pda="resolved3", market_question="Fed rate cut in Jan?",
+                side="Yes", amount=3.0, actual_pnl=2.2, outcome="won", is_resolved=True,
+            ),
+            Position(
+                market_pda="resolved4", market_question="XRP ETF approved?",
+                side="Yes", amount=2.0, actual_pnl=-2.0, outcome="lost", is_resolved=True,
+            ),
+            Position(
+                market_pda="resolved5", market_question="Nasdaq new ATH Jan?",
+                side="Yes", amount=5.0, actual_pnl=4.2, outcome="won", is_resolved=True,
+            ),
+            Position(
+                market_pda="resolved6", market_question="AI bill passed?",
+                side="No", amount=3.5, actual_pnl=2.8, outcome="won", is_resolved=True,
+            ),
+            Position(
+                market_pda="resolved7", market_question="Inflation below 2.5%?",
+                side="Yes", amount=2.0, actual_pnl=1.5, outcome="won", is_resolved=True,
+            ),
+        ],
+        total_wagered=45.2,
+        total_pnl=12.5,
+        accuracy=85.7,
+        win_streak=3,
+    )
+
+    sage = AgentStats(
+        wallet="Cr3pS4g3xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        name="CryptoSage",
+        open_positions=[
+            Position(
+                market_pda=m1.pda, market_question=m1.question,
+                side="Yes", amount=3.5,
+                unrealized_pnl=calc_unrealized_pnl("Yes", 3.5, m1),
+            ),
+        ],
+        resolved_positions=[
+            Position(
+                market_pda="resolved8", market_question="BTC $100k by Jan?",
+                side="Yes", amount=6.0, actual_pnl=4.1, outcome="won", is_resolved=True,
+            ),
+            Position(
+                market_pda="resolved9", market_question="ETH merge date?",
+                side="No", amount=4.0, actual_pnl=-4.0, outcome="lost", is_resolved=True,
+            ),
+            Position(
+                market_pda="resolved10", market_question="SOL flips BNB?",
+                side="Yes", amount=3.0, actual_pnl=2.3, outcome="won", is_resolved=True,
+            ),
+            Position(
+                market_pda="resolved11", market_question="AVAX above $50?",
+                side="Yes", amount=2.5, actual_pnl=1.8, outcome="won", is_resolved=True,
+            ),
+            Position(
+                market_pda="resolved12", market_question="Fed holds rates?",
+                side="No", amount=3.5, actual_pnl=-3.5, outcome="lost", is_resolved=True,
+            ),
+            Position(
+                market_pda="resolved13", market_question="Spot ETH ETF Q1?",
+                side="Yes", amount=4.0, actual_pnl=3.2, outcome="won", is_resolved=True,
+            ),
+            Position(
+                market_pda="resolved14", market_question="Memecoin crash?",
+                side="Yes", amount=2.0, actual_pnl=1.5, outcome="won", is_resolved=True,
+            ),
+        ],
+        total_wagered=38.1,
+        total_pnl=8.2,
+        accuracy=71.4,
+        win_streak=2,
+    )
+
+    bear = AgentStats(
+        wallet="Be4rB0txxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        name="BearBot",
+        open_positions=[
+            Position(
+                market_pda=m1.pda, market_question=m1.question,
+                side="No", amount=3.0,
+                unrealized_pnl=calc_unrealized_pnl("No", 3.0, m1),
+            ),
+            Position(
+                market_pda=m2.pda, market_question=m2.question,
+                side="Yes", amount=2.5,
+                unrealized_pnl=calc_unrealized_pnl("Yes", 2.5, m2),
+            ),
+        ],
+        resolved_positions=[
+            Position(
+                market_pda="resolved15", market_question="BTC crash below $80k?",
+                side="Yes", amount=4.0, actual_pnl=-4.0, outcome="lost", is_resolved=True,
+            ),
+            Position(
+                market_pda="resolved16", market_question="Market cap drop 20%?",
+                side="Yes", amount=3.0, actual_pnl=-3.0, outcome="lost", is_resolved=True,
+            ),
+            Position(
+                market_pda="resolved17", market_question="DeFi TVL down Q4?",
+                side="Yes", amount=2.0, actual_pnl=1.4, outcome="won", is_resolved=True,
+            ),
+            Position(
+                market_pda="resolved18", market_question="Stablecoin depeg?",
+                side="Yes", amount=3.5, actual_pnl=2.5, outcome="won", is_resolved=True,
+            ),
+            Position(
+                market_pda="resolved19", market_question="Binance delists?",
+                side="No", amount=2.5, actual_pnl=-2.5, outcome="lost", is_resolved=True,
+            ),
+            Position(
+                market_pda="resolved20", market_question="SOL below $100?",
+                side="Yes", amount=3.0, actual_pnl=-3.0, outcome="lost", is_resolved=True,
+            ),
+        ],
+        total_wagered=22.8,
+        total_pnl=-2.1,
+        accuracy=33.3,
+        win_streak=0,
+    )
+
+    agents = [alpha, sage, bear]
+
+    # Attach positions to markets
+    for agent in agents:
+        for pos in agent.open_positions:
+            for m in [m1, m2]:
+                if pos.market_pda == m.pda:
+                    m.positions.append((agent.name, pos))
+
+    active_markets = [m1, m2]
+
+    return agents, active_markets

--- a/submissions/agent-arena/mcp_client.py
+++ b/submissions/agent-arena/mcp_client.py
@@ -1,0 +1,133 @@
+"""
+mcp_client.py — Baozi MCP JSON-RPC wrapper.
+
+Spawns `npx @baozi.bet/mcp-server` as a subprocess and sends JSON-RPC
+requests over stdin/stdout.  Each public method sends init + tool call,
+parses the response, and returns typed Python data.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from typing import Any
+
+
+MCP_CMD = ["npx", "--yes", "@baozi.bet/mcp-server"]
+MCP_TIMEOUT = 30  # seconds per subprocess call
+
+
+def _rpc_call(tool_name: str, arguments: dict[str, Any]) -> Any:
+    """Send an initialize + tools/call request and return the parsed result."""
+    init = json.dumps({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "agent-arena", "version": "1.0"},
+        },
+    }) + "\n"
+
+    call = json.dumps({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/call",
+        "params": {"name": tool_name, "arguments": arguments},
+    }) + "\n"
+
+    try:
+        proc = subprocess.Popen(
+            MCP_CMD,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        out, err = proc.communicate(input=init + call, timeout=MCP_TIMEOUT)
+    except FileNotFoundError:
+        print("[mcp] npx not found — is Node.js installed?", file=sys.stderr)
+        return None
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        print(f"[mcp] timeout calling {tool_name}", file=sys.stderr)
+        return None
+    except Exception as exc:
+        print(f"[mcp] subprocess error: {exc}", file=sys.stderr)
+        return None
+
+    for line in out.strip().split("\n"):
+        try:
+            obj = json.loads(line)
+            if obj.get("id") == 2:
+                content = obj.get("result", {}).get("content", [])
+                if content:
+                    return json.loads(content[0].get("text", "null"))
+        except (json.JSONDecodeError, KeyError, IndexError):
+            continue
+
+    return None
+
+
+# ── public API ──────────────────────────────────────────────────────
+
+
+def list_markets(
+    layer: str = "Lab",
+    status: str = "Active",
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    """Return active markets from Baozi."""
+    data = _rpc_call("list_markets", {
+        "layer": layer,
+        "status": status,
+        "limit": limit,
+    })
+    if isinstance(data, dict):
+        return data.get("markets", [])
+    if isinstance(data, list):
+        return data
+    return []
+
+
+def get_market(market_pda: str) -> dict[str, Any] | None:
+    """Return pool state and odds for a single market."""
+    return _rpc_call("get_market", {"market": market_pda})
+
+
+def get_positions(wallet: str) -> list[dict[str, Any]]:
+    """Return all positions for a wallet address."""
+    data = _rpc_call("get_positions", {"wallet": wallet})
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        return data.get("positions", [])
+    return []
+
+
+def get_quote(
+    market_pda: str,
+    side: str = "Yes",
+    amount: float = 1.0,
+) -> dict[str, Any] | None:
+    """Get a quote (implied odds) for a hypothetical bet."""
+    return _rpc_call("get_quote", {
+        "market": market_pda,
+        "side": side,
+        "amount": amount,
+    })
+
+
+def discover_wallets(limit: int = 100) -> list[str]:
+    """Discover unique creator wallets from Lab markets."""
+    markets = list_markets(limit=limit)
+    wallets: list[str] = []
+    seen: set[str] = set()
+    for m in markets:
+        creator = m.get("creator") or m.get("authority") or m.get("wallet")
+        if creator and creator not in seen:
+            seen.add(creator)
+            wallets.append(creator)
+    return wallets

--- a/submissions/agent-arena/requirements.txt
+++ b/submissions/agent-arena/requirements.txt
@@ -1,0 +1,2 @@
+rich>=13.0
+requests>=2.28


### PR DESCRIPTION
## Submission for Bounty #36 — Agent Arena (1.0 SOL)

Real-time terminal dashboard monitoring multiple AI agent wallets competing on Baozi prediction markets.

### What this does

1. **Tracks 3+ wallets** simultaneously (parallel fetching via ThreadPoolExecutor)
2. **Live positions** per agent — market, side, amount, unrealized P&L
3. **Pari-mutuel P&L** calculation: `payout = (total_pool / side_pool) × amount × 0.97`
4. **Agent leaderboard** — ranked by P&L with accuracy %, win streak, volume
5. **Auto-refresh loop** every 30s (configurable via `--refresh`)
6. **Auto-discovers wallets** from active Lab market creators if fewer than 3 provided

### All acceptance criteria met
- ✅ Tracks 3+ wallets across active markets
- ✅ Shows live positions and P&L
- ✅ Agent leaderboard with accuracy stats
- ✅ Auto-refreshes without manual intervention
- ✅ Works with real mainnet data via MCP
- ✅ Clean Rich terminal UI
- ✅ README with setup + demo screenshots
- ✅ Demo mode: 3 agents, 2 markets, fully offline

### Files

```
submissions/agent-arena/
├── agent.py       — dashboard UI + refresh loop (Rich terminal)
├── arena.py       — core logic: positions, P&L, ranking, demo data
├── mcp_client.py  — MCP JSON-RPC wrapper (list_markets, get_positions, get_quote)
├── requirements.txt  — rich, requests
└── README.md
```

### Demo run

```bash
python agent.py --demo --once
```

Shows leaderboard + active markets with 3 competing agents, no API calls needed.

Wallet: `GZgrz2vtbc1o1kjipM1X3EFAf2VM54j9MVxGWSGbGmai`