### PR TITLE
feat: add Night Kitchen bilingual market report agent (closes #39)

### DIFF
--- a/scripts/night-kitchen-report/README.md
+++ b/scripts/night-kitchen-report/README.md
@@ -1,0 +1,36 @@
+# Night Kitchen — Bilingual Market Report (MVP)
+
+Generates a bilingual Baozi-style market report (english primary + chinese accents) with proverb selection based on market context.
+
+## Features
+
+- english-first report with chinese proverb lines
+- proverb selection by context:
+  - patience: long-dated markets
+  - risk: high pool/high-stakes markets
+  - luck: close races
+  - warmth: default/community tone
+- adapter for `@baozi.bet/mcp-server` style data access
+  - `BAOZI_API_BASE` configured: fetches `list_markets`
+  - no config: deterministic mock fallback
+- cli entrypoint to print report
+- tests for proverb logic + report format
+
+## Run
+
+```bash
+cd scripts/night-kitchen-report
+npm run report
+```
+
+## Test
+
+```bash
+cd scripts/night-kitchen-report
+npm test
+```
+
+## MCP Integration Note
+
+This MVP keeps MCP integration behind `src/mcpAdapter.js` so it can be upgraded to a full MCP client transport.
+Current default behavior uses fallback mock data when no api base/key is provided.

--- a/scripts/night-kitchen-report/package.json
+++ b/scripts/night-kitchen-report/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "night-kitchen-report",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "report": "node src/cli.js",
+    "test": "node --test"
+  }
+}

--- a/scripts/night-kitchen-report/src/cli.js
+++ b/scripts/night-kitchen-report/src/cli.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+import { listMarkets } from "./mcpAdapter.js";
+import { renderNightKitchenReport } from "./report.js";
+
+async function main() {
+  const markets = await listMarkets();
+  const report = renderNightKitchenReport(markets);
+  console.log(report);
+}
+
+main().catch((err) => {
+  console.error("night-kitchen-report failed:", err.message);
+  process.exit(1);
+});

--- a/scripts/night-kitchen-report/src/mcpAdapter.js
+++ b/scripts/night-kitchen-report/src/mcpAdapter.js
@@ -1,0 +1,53 @@
+/**
+ * Adapter for @baozi.bet/mcp-server compatible data access.
+ *
+ * MVP behavior:
+ * - If BAOZI_API_BASE is provided, fetches from `${base}/api/mcp/list_markets` (JSON).
+ * - Otherwise falls back to deterministic mock data (works without keys/network).
+ */
+
+const MOCK_MARKETS = [
+  {
+    id: "m1",
+    question: "will btc hit $110k by april 1?",
+    yes: 0.58,
+    no: 0.42,
+    poolSol: 32.4,
+    closesInHours: 240,
+    resolved: false
+  },
+  {
+    id: "m2",
+    question: "who wins nba all-star mvp?",
+    outcomes: [
+      ["lebron", 0.35],
+      ["tatum", 0.28],
+      ["jokic", 0.22],
+      ["other", 0.15]
+    ],
+    poolSol: 18.7,
+    closesInHours: 48,
+    resolved: false
+  },
+  {
+    id: "m3",
+    question: "will sol close above $220 this week?",
+    yes: 0.51,
+    no: 0.49,
+    poolSol: 61.2,
+    closesInHours: 8,
+    resolved: false
+  }
+];
+
+export async function listMarkets() {
+  const base = process.env.BAOZI_API_BASE;
+  if (!base) return MOCK_MARKETS;
+
+  const url = `${base.replace(/\/$/, "")}/api/mcp/list_markets`;
+  const res = await fetch(url, { headers: { "content-type": "application/json" } });
+  if (!res.ok) throw new Error(`failed list_markets: ${res.status}`);
+  const data = await res.json();
+  if (!Array.isArray(data?.markets)) throw new Error("invalid list_markets response");
+  return data.markets;
+}

--- a/scripts/night-kitchen-report/src/proverbs.js
+++ b/scripts/night-kitchen-report/src/proverbs.js
@@ -1,0 +1,28 @@
+export const PROVERBS = {
+  patience: [
+    { zh: "心急吃不了热豆腐", en: "you can't rush hot tofu — patience." },
+    { zh: "慢工出细活", en: "slow work, fine craft." },
+    { zh: "好饭不怕晚", en: "good food doesn't fear being late." },
+    { zh: "火候到了，自然熟", en: "right heat, naturally cooked." }
+  ],
+  risk: [
+    { zh: "贪多嚼不烂", en: "bite off too much, can't chew." },
+    { zh: "见好就收", en: "quit while ahead." },
+    { zh: "民以食为天", en: "food is heaven for people — remember fundamentals." }
+  ],
+  luck: [
+    { zh: "谋事在人成事在天", en: "you make your bet, the market decides." },
+    { zh: "知足常乐", en: "contentment brings happiness." }
+  ],
+  warmth: [
+    { zh: "小小一笼大大缘分", en: "small steamer, big fate." },
+    { zh: "好饭不怕晚", en: "good food doesn't fear being late." }
+  ]
+};
+
+export function selectProverb(context, used = new Set()) {
+  const bucket = PROVERBS[context] ?? PROVERBS.warmth;
+  const candidate = bucket.find((p) => !used.has(p.zh)) ?? bucket[0];
+  used.add(candidate.zh);
+  return candidate;
+}

--- a/scripts/night-kitchen-report/src/report.js
+++ b/scripts/night-kitchen-report/src/report.js
@@ -1,0 +1,53 @@
+import { selectProverb } from "./proverbs.js";
+
+function pickContext(market) {
+  if (market.closesInHours >= 72) return "patience";
+  if ((market.poolSol ?? 0) >= 50) return "risk";
+
+  const spread = market.outcomes
+    ? Math.abs((market.outcomes[0]?.[1] ?? 0.5) - (market.outcomes[1]?.[1] ?? 0.5))
+    : Math.abs((market.yes ?? 0.5) - (market.no ?? 0.5));
+  if (spread <= 0.08) return "luck";
+
+  return "warmth";
+}
+
+function formatOdds(m) {
+  if (m.outcomes) {
+    return m.outcomes.map(([name, p]) => `${name}: ${Math.round(p * 100)}%`).join(" | ");
+  }
+  return `yes: ${Math.round((m.yes ?? 0) * 100)}% | no: ${Math.round((m.no ?? 0) * 100)}%`;
+}
+
+export function renderNightKitchenReport(markets, now = new Date()) {
+  const used = new Set();
+  const date = now.toISOString().slice(0, 10);
+
+  const lines = [
+    "夜厨房 — night kitchen report",
+    date,
+    "",
+    `${markets.length} markets simmering tonight.`,
+    ""
+  ];
+
+  for (const m of markets) {
+    const ctx = pickContext(m);
+    const proverb = selectProverb(ctx, used);
+
+    lines.push(`🥟 ${m.question}`);
+    lines.push(`   ${formatOdds(m)}`);
+    lines.push(`   pool: ${(m.poolSol ?? 0).toFixed(1)} sol | closes in ${m.closesInHours}h`);
+    lines.push("");
+    lines.push(`   ${proverb.zh}`);
+    lines.push(`   \"${proverb.en}\"`);
+    lines.push("");
+  }
+
+  lines.push("───────────────");
+  lines.push("");
+  lines.push("this is still gambling. play small, play soft.");
+  lines.push("baozi.bet | 小小一笼，大大缘分");
+
+  return lines.join("\n").toLowerCase();
+}

--- a/scripts/night-kitchen-report/test/report.test.js
+++ b/scripts/night-kitchen-report/test/report.test.js
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { selectProverb } from "../src/proverbs.js";
+import { renderNightKitchenReport } from "../src/report.js";
+
+test("selectProverb reuses category but avoids immediate duplicates", () => {
+  const used = new Set();
+  const p1 = selectProverb("patience", used);
+  const p2 = selectProverb("patience", used);
+  assert.notEqual(p1.zh, p2.zh);
+});
+
+test("renderNightKitchenReport outputs bilingual format and disclaimers", () => {
+  const report = renderNightKitchenReport([
+    { question: "will btc hit $110k?", yes: 0.58, no: 0.42, poolSol: 32.4, closesInHours: 240 },
+    { question: "will sol close above $220?", yes: 0.51, no: 0.49, poolSol: 61.2, closesInHours: 8 }
+  ], new Date("2026-02-19T00:00:00Z"));
+
+  assert.match(report, /夜厨房 — night kitchen report/);
+  assert.match(report, /心急吃不了热豆腐|慢工出细活|好饭不怕晚|火候到了，自然熟/);
+  assert.match(report, /this is still gambling\. play small, play soft\./);
+  assert.match(report, /baozi\.bet \| 小小一笼，大大缘分/);
+});


### PR DESCRIPTION
## Summary
Adds an MVP Night Kitchen agent that generates Baozi-style bilingual (english + chinese) market reports with context-aware proverb selection.

## Changes
- Added `scripts/night-kitchen-report` standalone package with CLI entrypoint
- Implemented proverb library + selection logic for patience/risk/luck/warmth contexts
- Added market context classifier and bilingual report formatter in Baozi brand voice
- Added MCP integration adapter (`mcpAdapter.js`) with `list_markets` path and mock fallback when no API base/key is available
- Added README with setup/run/test instructions
- Added tests covering proverb selection and report output format

## Testing
- `cd scripts/night-kitchen-report && npm test`
- `cd scripts/night-kitchen-report && npm run report`

## Notes
- This MVP is runnable without secrets via deterministic mock markets.
- Adapter design allows swapping in full `@baozi.bet/mcp-server` transport without changing report logic.
- Included risk language: "this is still gambling. play small, play soft." per issue guidance.
